### PR TITLE
Allow unicode messages to be displayed in Django Administration

### DIFF
--- a/post_office/admin.py
+++ b/post_office/admin.py
@@ -4,7 +4,7 @@ from .models import Email, Log, EmailTemplate
 
 
 def get_message_preview(instance):
-    return ('{0}...'.format(instance.message[:25]) if len(instance.message) > 25
+    return (u'{0}...'.format(instance.message[:25]) if len(instance.message) > 25
             else instance.message)
 
 get_message_preview.short_description = 'Message'


### PR DESCRIPTION
I've got this error trying to display a list of emails containing unicode characters in their message body:

```
File "..../python2.7/site-packages/post_office/admin.py", line 7, in get_message_preview
return ('{0}...'.format(instance.message[:25]) if len(instance.message) > 25

UnicodeEncodeError: 'ascii' codec can't encode characters in position 0-7: ordinal not in range(128)
```

The issue seem quite easy to fix by replacing the '{0}...' ASCII string with the same unicode text.

This patch just adds the 'u' marker to the ''{0}...' string.

Thank you.
