### PR TITLE
Fixes header setting when sending through post_office.EmailBackend

### DIFF
--- a/post_office/backends.py
+++ b/post_office/backends.py
@@ -25,6 +25,7 @@ class EmailBackend(BaseEmailBackend):
             subject = email.subject
             from_email = email.from_email
             message = email.body
+            headers = email.extra_headers
 
             # Check whether email has 'text/html' alternative
             alternatives = getattr(email, 'alternatives', ())
@@ -39,4 +40,4 @@ class EmailBackend(BaseEmailBackend):
                 Email.objects.create(from_email=from_email, to=recipient,
                     subject=subject, html_message=html_message,
                     message=message, status=STATUS.queued,
-                    priority=PRIORITY.medium)
+                    headers=headers, priority=PRIORITY.medium)

--- a/post_office/tests/backends.py
+++ b/post_office/tests/backends.py
@@ -1,5 +1,5 @@
 from django.conf import settings
-from django.core.mail import backends, EmailMultiAlternatives, send_mail
+from django.core.mail import backends, EmailMultiAlternatives, send_mail, EmailMessage
 from django.test import TestCase
 from django.test.utils import override_settings
 
@@ -71,3 +71,15 @@ class BackendTest(TestCase):
         message.send()
         email = Email.objects.latest('id')
         self.assertEqual(email.html_message, 'html')
+
+    @override_settings(EMAIL_BACKEND='post_office.EmailBackend')
+    def test_headers_sent(self):
+        """
+        Test that headers are correctly set on the outgoing emails.
+        """
+        message = EmailMessage('subject', 'body', 'from@example.com',
+                               ['recipient@example.com'],
+                               headers={'Reply-To': 'reply@example.com'})
+        message.send()
+        email = Email.objects.latest('id')
+        self.assertEqual(email.headers, {'Reply-To': 'reply@example.com'})


### PR DESCRIPTION
The extra headers were not set when sending an email using `EmailMessage.send()`.
This patch fixes that.
