### PR TITLE
Allow passing priority as string

### DIFF
--- a/post_office/mail.py
+++ b/post_office/mail.py
@@ -61,7 +61,8 @@ def send(recipients, sender=None, template=None, context={}, subject='',
         priority = getattr(PRIORITY, priority, None)
 
         if priority is None:
-            raise ValueError('Invalid priority')
+            raise ValueError('Invalid priority, must be one of: %s' %
+                             ', '.join(PRIORITY._fields))
 
     if template:
         if subject:

--- a/post_office/tests/models.py
+++ b/post_office/tests/models.py
@@ -238,6 +238,7 @@ class ModelTest(TestCase):
             'content': [u"Invalid filter: 'titl'"],
             'html_content': [u"Unclosed tags: endblock "]
         })
+
     def test_string_priority(self):
         """
         Regression test for:
@@ -249,4 +250,11 @@ class ModelTest(TestCase):
 
     def test_string_priority_exception(self):
         invalid_priority_send = lambda: send(['to1@example.com'], 'from@a.com', priority='hgh')
-        self.assertRaises(ValueError, invalid_priority_send)
+
+        with self.assertRaises(ValueError) as context:
+            invalid_priority_send()
+
+        self.assertEquals(
+            context.exception.message,
+            'Invalid priority, must be one of: low, medium, high, now'
+        )


### PR DESCRIPTION
According to the tutorial, send() should accept the string representation of `priority`.
Ref #23
