### PR TITLE
Fixed post_office logger set on the root

### DIFF
--- a/post_office/logutils.py
+++ b/post_office/logutils.py
@@ -27,9 +27,11 @@ def setup_loghandlers(level=None):
                 },
             },
 
-            "root": {
-                "handlers": ["post_office"],
-                "level": level or "DEBUG"
+            "loggers": {
+                "post_office": {
+                    "handlers": ["post_office"],
+                    "level": level or "DEBUG"
+                }
             }
         })
     return logger


### PR DESCRIPTION
`posf_office` loggers will overwrite logging configuration on the `root` level if not configured.

This should not be the default behavior, as this will overwrite logging configuration of other module, such as Django's default logging configuration

This PR will fix this issue by configuring logger to `post_office` module only, as opposed to root level
