### PR TITLE
Multilingual templates using ModelTranslation

### DIFF
--- a/post_office/admin.py
+++ b/post_office/admin.py
@@ -1,6 +1,11 @@
 from django.contrib import admin
 from django.utils.text import Truncator
 
+try:
+    from modeltranslation.admin import TranslationAdmin
+except ImportError:
+    from django.contrib.admin import ModelAdmin as TranslationAdmin
+
 from .models import Email, Log, EmailTemplate
 
 
@@ -29,7 +34,7 @@ class LogAdmin(admin.ModelAdmin):
     list_display = ('date', 'email', 'status', get_message_preview)
 
 
-class EmailTemplateAdmin(admin.ModelAdmin):
+class EmailTemplateAdmin(TranslationAdmin):
     list_display = ('name', 'description_shortened', 'subject', 'created')
     search_fields = ('name', 'description', 'subject')
     fieldsets = [
@@ -45,7 +50,6 @@ class EmailTemplateAdmin(admin.ModelAdmin):
         return Truncator(instance.description.split('\n')[0]).chars(200)
     description_shortened.short_description = 'description'
     description_shortened.admin_order_field = 'description'
-
 
 admin.site.register(Email, EmailAdmin)
 admin.site.register(Log, LogAdmin)

--- a/post_office/translation.py
+++ b/post_office/translation.py
@@ -1,0 +1,9 @@
+from modeltranslation.translator import translator, TranslationOptions
+
+from .models import EmailTemplate
+
+
+class EmailTemplateTranslationOptions(TranslationOptions):
+    fields = ('subject', 'content', 'html_content', )
+
+translator.register(EmailTemplate, EmailTemplateTranslationOptions)


### PR DESCRIPTION
Added a optional dependency for [ModelTranslation](https://github.com/deschler/django-modeltranslation) this will allow users a easy way to support mail template translations.
This is related to ui/django-post_office#32
