### PR TITLE
Add description field to email template

### DIFF
--- a/post_office/admin.py
+++ b/post_office/admin.py
@@ -1,4 +1,5 @@
 from django.contrib import admin
+from django.utils.text import Truncator
 
 from .models import Email, Log, EmailTemplate
 
@@ -29,7 +30,22 @@ class LogAdmin(admin.ModelAdmin):
 
 
 class EmailTemplateAdmin(admin.ModelAdmin):
-    list_display = ('name', 'subject', 'created')
+    list_display = ('name', 'description_shortened', 'subject', 'created')
+    search_fields = ('name', 'description', 'subject')
+    fieldsets = [
+        (None, {
+            'fields': ('name', 'description'),
+        }),
+        ('Email', {
+            'fields': ('subject', 'content', 'html_content'),
+        }),
+    ]
+
+    def description_shortened(self, instance):
+        return Truncator(instance.description.split('\n')[0]).chars(200)
+    description_shortened.short_description = 'description'
+    description_shortened.admin_order_field = 'description'
+
 
 admin.site.register(Email, EmailAdmin)
 admin.site.register(Log, LogAdmin)

--- a/post_office/migrations/0006_auto__add_field_emailtemplate_description.py
+++ b/post_office/migrations/0006_auto__add_field_emailtemplate_description.py
@@ -1,0 +1,66 @@
+# -*- coding: utf-8 -*-
+from south.utils import datetime_utils as datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        # Adding field 'EmailTemplate.description'
+        db.add_column(u'post_office_emailtemplate', 'description',
+                      self.gf('django.db.models.fields.TextField')(default='', blank=True),
+                      keep_default=False)
+
+
+    def backwards(self, orm):
+        # Deleting field 'EmailTemplate.description'
+        db.delete_column(u'post_office_emailtemplate', 'description')
+
+
+    models = {
+        u'post_office.attachment': {
+            'Meta': {'object_name': 'Attachment'},
+            'emails': ('django.db.models.fields.related.ManyToManyField', [], {'related_name': "'attachments'", 'symmetrical': 'False', 'to': u"orm['post_office.Email']"}),
+            'file': ('django.db.models.fields.files.FileField', [], {'max_length': '100'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '255'})
+        },
+        u'post_office.email': {
+            'Meta': {'ordering': "('-created',)", 'object_name': 'Email'},
+            'created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'db_index': 'True', 'blank': 'True'}),
+            'from_email': ('django.db.models.fields.CharField', [], {'max_length': '254'}),
+            'headers': ('jsonfield.fields.JSONField', [], {'null': 'True', 'blank': 'True'}),
+            'html_message': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'last_updated': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'db_index': 'True', 'blank': 'True'}),
+            'message': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'priority': ('django.db.models.fields.PositiveSmallIntegerField', [], {'db_index': 'True', 'null': 'True', 'blank': 'True'}),
+            'scheduled_time': ('django.db.models.fields.DateTimeField', [], {'db_index': 'True', 'null': 'True', 'blank': 'True'}),
+            'status': ('django.db.models.fields.PositiveSmallIntegerField', [], {'db_index': 'True', 'null': 'True', 'blank': 'True'}),
+            'subject': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'to': ('django.db.models.fields.EmailField', [], {'max_length': '254'})
+        },
+        u'post_office.emailtemplate': {
+            'Meta': {'ordering': "('name',)", 'object_name': 'EmailTemplate'},
+            'content': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'description': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'html_content': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'last_updated': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'subject': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'})
+        },
+        u'post_office.log': {
+            'Meta': {'ordering': "('-date',)", 'object_name': 'Log'},
+            'date': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'db_index': 'True', 'blank': 'True'}),
+            'email': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'logs'", 'to': u"orm['post_office.Email']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'message': ('django.db.models.fields.TextField', [], {}),
+            'status': ('django.db.models.fields.PositiveSmallIntegerField', [], {'db_index': 'True'})
+        }
+    }
+
+    complete_apps = ['post_office']

--- a/post_office/models.py
+++ b/post_office/models.py
@@ -156,6 +156,8 @@ class EmailTemplate(models.Model):
     Model to hold template information from db
     """
     name = models.CharField(max_length=255, help_text=("Example: 'emails/customers/id/welcome.html'"))
+    description = models.TextField(blank=True,
+            help_text='Description of this email template. The first line of the description will be displayed in the admin list.')
     subject = models.CharField(max_length=255, blank=True,
                                validators=[validate_template_syntax])
     content = models.TextField(blank=True,


### PR DESCRIPTION
This field can be used for a human readable description of the email
template. e.g. for providing information when this email template is
used and which context variables are available.

This obsoletes #41
