### PR TITLE
Fix admin login

### DIFF
--- a/post_office/tests/views.py
+++ b/post_office/tests/views.py
@@ -16,7 +16,7 @@ class AdminViewTest(TestCase):
     def setUp(self):
         user = User.objects.create_superuser(admin_username, admin_email, admin_pass)
         self.client = Client()
-        self.client.login(username=user.username, password=user.password)
+        self.client.login(username=user.username, password=admin_pass)
 
     # Small test to make sure the admin interface is loaded
     def test_admin_interface(self):


### PR DESCRIPTION
The password is not stored in the User model, so self.client.login will fail and the 200 response you get is the admin login form. Changing to use the raw password causes login to succeed and then the 500 error shows up.

Refs issue #43
