### PR TITLE
Add setting for email default priority (PR for #51)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -267,6 +267,19 @@ number of queued emails fetched in one batch.
         'BATCH_SIZE': 5000
     }
 
+Default priority
+----------------
+
+The default priority for emails is ``'medium'``, but this can be altered by
+setting ``DEFAULT_PRIORITY``. Integration with asynchronous email backends
+(e.g. based on Celery) becomes trivial when set to ``'now'``.
+
+.. code-block:: python
+
+    POST_OFFICE = {
+        'DEFAULT_PRIORITY': 'now'
+    }
+
 
 Performance
 ===========
@@ -338,6 +351,12 @@ To run ``post_office``'s test suite::
 
 Changelog
 =========
+
+Unreleased
+----------
+* Added a new setting ``DEFAULT_PRIORITY`` to set the default priority for emails.
+* All settings in post_office.mail now support passing a priority as string,
+  e.g. ``'low'``.
 
 Version 0.7.2
 -------------

--- a/post_office/settings.py
+++ b/post_office/settings.py
@@ -41,3 +41,6 @@ def get_config():
 
 def get_batch_size():
     return get_config().get('BATCH_SIZE', 5000)
+
+def get_default_priority():
+    return get_config().get('DEFAULT_PRIORITY', 'medium')

--- a/post_office/tests/models.py
+++ b/post_office/tests/models.py
@@ -248,6 +248,10 @@ class ModelTest(TestCase):
         emails = send(['to1@example.com'], 'from@a.com', priority='low')
         self.assertEqual(emails[0].priority, PRIORITY.low)
 
+    def test_default_priority(self):
+        emails = send(['to1@example.com'], 'from@a.com')
+        self.assertEqual(emails[0].priority, PRIORITY.medium)
+
     def test_string_priority_exception(self):
         invalid_priority_send = lambda: send(['to1@example.com'], 'from@a.com', priority='hgh')
 


### PR DESCRIPTION
This greatly facilitates integration with async backends (e.g. Celery-based ones).

Tests pass with Django 1.5. Django 1.6's new test runner doesn't seem to pick up any tests.
