### PR TITLE
Updated context field class to be null=True

### DIFF
--- a/post_office/models.py
+++ b/post_office/models.py
@@ -57,7 +57,7 @@ class Email(models.Model):
     scheduled_time = models.DateTimeField(blank=True, null=True, db_index=True)
     headers = JSONField(blank=True, null=True)
     template = models.ForeignKey('post_office.EmailTemplate', blank=True, null=True)
-    context = context_field_class(blank=True)
+    context = context_field_class(blank=True, null=True)
 
     def __unicode__(self):
         return u'%s' % self.to


### PR DESCRIPTION
This is specific to issues created by JSONField and that in order to get a valid empty value with PostgreSQL we need null=True so JSONField will set the value right. Without this fix Django will produce a validation error on records which will contain < "" > instead of a null value as needed by PostgreSQL.
