### PR TITLE
mail.create also renders with empty context. test for that added.

### DIFF
--- a/post_office/mail.py
+++ b/post_office/mail.py
@@ -66,11 +66,10 @@ def create(sender, recipients=None, cc=None, bcc=None, subject='', message='',
             message = template.content
             html_message = template.html_content
 
-        if context:
-            _context = Context(context)
-            subject = Template(subject).render(_context)
-            message = Template(message).render(_context)
-            html_message = Template(html_message).render(_context)
+        _context = Context(context or {})
+        subject = Template(subject).render(_context)
+        message = Template(message).render(_context)
+        html_message = Template(html_message).render(_context)
 
         email = Email(
             from_email=sender,

--- a/post_office/tests/mail.py
+++ b/post_office/tests/mail.py
@@ -280,6 +280,29 @@ class MailTest(TestCase):
         self.assertEqual(email.context, context)
         self.assertEqual(email.template, template)
 
+    def test_create_with_template_and_empty_context(self):
+        """If render_on_delivery is False, subject and content
+        will be rendered, context won't be saved."""
+
+        template = EmailTemplate.objects.create(
+            subject='Subject {% now "Y" %}',
+            content='Content {% now "Y" %}',
+            html_content='HTML {% now "Y" %}'
+        )
+        context = None
+        email = create(
+            sender='from@example.com', recipients=['to@example.com'],
+            template=template, context=context
+        )
+        from datetime import date
+        today = date.today()
+        current_year = today.year
+        self.assertEqual(email.subject, 'Subject %d' % current_year)
+        self.assertEqual(email.message, 'Content %d' % current_year)
+        self.assertEqual(email.html_message, 'HTML %d' % current_year)
+        self.assertEqual(email.context, None)
+        self.assertEqual(email.template, None)
+
     def test_send_with_template(self):
         """If render_on_delivery is False, subject and content
         will be rendered, context won't be saved."""


### PR DESCRIPTION
in response to https://github.com/ui/django-post_office/issues/84
