### PR TITLE
Fix missing app_label deprecation warnings (Django 1.9)

### DIFF
--- a/post_office/models.py
+++ b/post_office/models.py
@@ -224,3 +224,6 @@ class Attachment(models.Model):
     file = models.FileField(upload_to=get_upload_path)
     name = models.CharField(max_length=255, help_text=_("The original filename"))
     emails = models.ManyToManyField(Email, related_name='attachments')
+
+    class Meta:
+        app_label = 'post_office'


### PR DESCRIPTION
Fixes the warning:

> /lib/python3.4/site-packages/post_office/models.py:220: RemovedInDjango19Warning: Model class post_office.models.Attachment doesn't declare an explicit app_label and either isn't in an application in INSTALLED_APPS or else was imported before its application was loaded. This will no longer be supported in Django 1.9.
