### PR TITLE
Bugfix for SMTPServerDisconnected

### DIFF
--- a/post_office/mail.py
+++ b/post_office/mail.py
@@ -240,7 +240,8 @@ def _send_bulk(emails, uses_multiprocessing=True, log_level=None):
 
     try:
         for email in emails:
-            status = email.dispatch(log_level=log_level)
+            status = email.dispatch(log_level=log_level,
+                                    disconnect_after_delivery=False)
             if status == STATUS.sent:
                 sent_count += 1
                 logger.debug('Successfully sent email #%d' % email.id)

--- a/post_office/models.py
+++ b/post_office/models.py
@@ -114,8 +114,9 @@ class Email(models.Model):
         if log_level is None:
             log_level = get_log_level()
 
-        connection = connections[self.backend_alias or 'default']
+        connection = None
         try:
+            connection = connections[self.backend_alias or 'default']
             self.email_message(connection=connection).send()
             status = STATUS.sent
             message = ''
@@ -125,7 +126,7 @@ class Email(models.Model):
             exception, message, _ = sys.exc_info()
             exception_type = exception.__name__
 
-        if disconnect_after_delivery:
+        if connection and disconnect_after_delivery:
             connection.close()
 
         self.status = status

--- a/post_office/models.py
+++ b/post_office/models.py
@@ -120,11 +120,12 @@ class Email(models.Model):
             status = STATUS.sent
             message = ''
             exception_type = ''
-
         except:
             status = STATUS.failed
             exception, message, _ = sys.exc_info()
             exception_type = exception.__name__
+        else:
+            connection.close()
 
         self.status = status
         self.save()


### PR DESCRIPTION
Occasionally we had failed mails with the exception `SMTPServerDisconnected` and message `"please run connect() first"`. We noticed that this happened when calling `post_office.mail.send` with `priority='now'` only and not when using the post_office management command.

After some digging and trying to replicate the problem in the shell (which worked fine using `'now'` at first) I found out that the session is not closed after an email has been sent. So I guess this depends on the email provider you use, but for us after some time the remote server dropped the connection. When trying to send through this connection than, naturally the `SMTPServerDisconnected` exception occurs.

I could only find the django `send()` call once and added a `connection.close()` when it was successful. So far this fixed the issue.