### PR TITLE
Fix and improve model str() method

### DIFF
--- a/post_office/models.py
+++ b/post_office/models.py
@@ -9,6 +9,7 @@ from django.conf import settings
 from django.core.mail import EmailMessage, EmailMultiAlternatives
 from django.db import models
 from django.utils.translation import ugettext_lazy as _
+from django.utils.encoding import python_2_unicode_compatible
 from post_office.fields import CommaSeparatedEmailField
 
 try:
@@ -30,6 +31,7 @@ PRIORITY = namedtuple('PRIORITY', 'low medium high now')._make(range(4))
 STATUS = namedtuple('STATUS', 'sent failed queued')._make(range(3))
 
 
+@python_2_unicode_compatible
 class Email(models.Model):
     """
     A model to hold email information.
@@ -68,7 +70,7 @@ class Email(models.Model):
     class Meta:
         app_label = 'post_office'
 
-    def __unicode__(self):
+    def __str__(self):
         return u'%s' % self.to
 
     def email_message(self, connection=None):
@@ -149,6 +151,7 @@ class Email(models.Model):
         return super(Email, self).save(*args, **kwargs)
 
 
+@python_2_unicode_compatible
 class Log(models.Model):
     """
     A model to record sending email sending activities.
@@ -165,10 +168,11 @@ class Log(models.Model):
     class Meta:
         app_label = 'post_office'
 
-    def __unicode__(self):
+    def __str__(self):
         return text_type(self.date)
 
 
+@python_2_unicode_compatible
 class EmailTemplate(models.Model):
     """
     Model to hold template information from db
@@ -196,7 +200,7 @@ class EmailTemplate(models.Model):
         verbose_name = _("Email Template")
         verbose_name_plural = _("Email Templates")
 
-    def __unicode__(self):
+    def __str__(self):
         return self.name
 
     def save(self, *args, **kwargs):

--- a/post_office/models.py
+++ b/post_office/models.py
@@ -201,7 +201,7 @@ class EmailTemplate(models.Model):
         verbose_name_plural = _("Email Templates")
 
     def __str__(self):
-        return self.name
+        return u'%s %s' % (self.name, self.language)
 
     def save(self, *args, **kwargs):
         # If template is a translation, use default template's name

--- a/post_office/tests/test_models.py
+++ b/post_office/tests/test_models.py
@@ -269,3 +269,9 @@ class ModelTest(TestCase):
         template = EmailTemplate.objects.create(name='name')
         id_template = template.translated_templates.create(language='id')
         self.assertEqual(id_template.name, template.name)
+
+    def test_models_repr(self):
+        self.assertEqual(repr(EmailTemplate(name='test', language='en')),
+                         '<EmailTemplate: test en>')
+        self.assertEqual(repr(Email(to='test@example.com')),
+                         "<Email: ['test@example.com']>")


### PR DESCRIPTION
Ref #135

* str(EmailTemplate) was broken for Python 3. Replaced `__unicode__` with `__str__` and a `@python_2_unicode_compatible` decorator.
* Add language to `EmailTemplate.__str__()` method.
* Test repr() of models.