### PR TITLE
README log level

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -393,6 +393,7 @@ This behavior can be changed by setting ``LOG_LEVEL``.
     }
 
 The different options are:
+
 * ``0`` logs nothing
 * ``1`` logs only failed deliveries
 * ``2`` logs everything (both successful and failed delivery attempts)


### PR DESCRIPTION
spaced out options for markdown to work.