### PR TITLE
Cleanup compat imports

### DIFF
--- a/post_office/compat.py
+++ b/post_office/compat.py
@@ -23,6 +23,21 @@ else:
     text_type = unicode
 
 
+try:
+    from django.core.cache import caches  # Django >= 1.7
+
+    def get_cache(name):
+        return caches[name]
+except ImportError:
+    from django.core.cache import get_cache
+
+
+try:
+    from django.utils.encoding import smart_text  # For Django >= 1.5
+except ImportError:
+    from django.utils.encoding import smart_unicode as smart_text
+
+
 # Django 1.4 doesn't have ``import_string`` or ``import_by_path``
 def import_attribute(name):
     """Return an attribute from a dotted path name (e.g. "path.to.func")."""

--- a/post_office/mail.py
+++ b/post_office/mail.py
@@ -7,6 +7,7 @@ from django.core.exceptions import ValidationError
 from django.db import connection as db_connection
 from django.db.models import Q
 from django.template import Context, Template
+from django.utils.timezone import now
 
 from .connections import connections
 from .models import Email, EmailTemplate, PRIORITY, STATUS
@@ -15,13 +16,6 @@ from .settings import (get_available_backends, get_batch_size,
 from .utils import (get_email_template, parse_emails, parse_priority,
                     split_emails, create_attachments)
 from .logutils import setup_loghandlers
-
-try:
-    from django.utils import timezone
-    now = timezone.now
-except ImportError:
-    import datetime
-    now = datetime.datetime.now
 
 
 logger = setup_loghandlers("INFO")

--- a/post_office/management/commands/cleanup_mail.py
+++ b/post_office/management/commands/cleanup_mail.py
@@ -2,15 +2,9 @@ import datetime
 from optparse import make_option
 
 from django.core.management.base import BaseCommand
+from django.utils.timezone import now
 
 from ...models import Email
-
-
-try:
-    from django.utils.timezone import now
-    now = now
-except ImportError:
-    now = datetime.now
 
 
 class Command(BaseCommand):

--- a/post_office/models.py
+++ b/post_office/models.py
@@ -11,16 +11,11 @@ from django.utils.translation import ugettext_lazy as _
 from django.utils.encoding import python_2_unicode_compatible
 from post_office.fields import CommaSeparatedEmailField
 
-try:
-    from django.utils.encoding import smart_text  # For Django >= 1.5
-except ImportError:
-    from django.utils.encoding import smart_unicode as smart_text
-
 from django.template import Context, Template
 
 from jsonfield import JSONField
 from post_office import cache
-from .compat import text_type
+from .compat import text_type, smart_text
 from .connections import connections
 from .settings import context_field_class, get_log_level
 from .validators import validate_email_with_name, validate_template_syntax

--- a/post_office/settings.py
+++ b/post_office/settings.py
@@ -3,16 +3,7 @@ import warnings
 from django.conf import settings
 from django.core.cache.backends.base import InvalidCacheBackendError
 
-from .compat import import_attribute
-
-
-try:
-    from django.core.cache import caches
-
-    def get_cache(name):
-        return caches[name]
-except ImportError:
-    from django.core.cache import get_cache
+from .compat import import_attribute, get_cache
 
 
 def get_backend(alias='default'):

--- a/post_office/tests/test_commands.py
+++ b/post_office/tests/test_commands.py
@@ -2,14 +2,9 @@ import datetime
 
 from django.core.management import call_command
 from django.test import TestCase
+from django.utils.timezone import now
 
 from ..models import Email, STATUS
-
-try:
-    from django.utils.timezone import now
-    now = now
-except ImportError:
-    now = datetime.now
 
 
 class CommandTest(TestCase):

--- a/post_office/tests/test_mail.py
+++ b/post_office/tests/test_mail.py
@@ -302,7 +302,6 @@ class MailTest(TestCase):
             sender='from@example.com', recipients=['to@example.com'],
             template=template, context=context
         )
-        from datetime import date
         today = date.today()
         current_year = today.year
         self.assertEqual(email.subject, 'Subject %d' % current_year)

--- a/post_office/utils.py
+++ b/post_office/utils.py
@@ -14,14 +14,6 @@ from .settings import get_default_priority
 from .validators import validate_email_with_name
 
 
-try:
-    from django.utils import timezone
-    now = timezone.now
-except ImportError:
-    import datetime
-    now = datetime.datetime.now
-
-
 def send_mail(subject, message, from_email, recipient_list, html_message='',
               scheduled_time=None, headers=None, priority=PRIORITY.medium):
     """

--- a/post_office/utils.py
+++ b/post_office/utils.py
@@ -1,11 +1,7 @@
 from django.conf import settings
 from django.core.exceptions import ValidationError
 from django.core.files import File
-
-try:
-    from django.utils.encoding import force_text
-except ImportError:
-    from django.utils.encoding import force_unicode as force_text
+from django.utils.encoding import force_text
 
 from post_office import cache
 from .compat import string_types


### PR DESCRIPTION
*  Remove old compat imports for `django.utils.timezone.now` (works in Django 1.4+)
*  Remove old compat import for `force_text`.
* Move scattered compatibility imports to compat.py and document versions.

This should make dropping older Django / Python versions and supporting new ones easier.