### PR TITLE
Fix POST_OFFICE_CACHE and POST_OFFICE_TEMPLATE_CACHE behavior

### DIFF
--- a/post_office/test_settings.py
+++ b/post_office/test_settings.py
@@ -7,6 +7,10 @@ DATABASES = {
     },
 }
 
+# Default values: True
+# POST_OFFICE_CACHE = True
+# POST_OFFICE_TEMPLATE_CACHE = True
+
 
 CACHES = {
     'default': {

--- a/post_office/tests/test_utils.py
+++ b/post_office/tests/test_utils.py
@@ -90,7 +90,7 @@ class UtilsTest(TestCase):
             """Raise exception if real cache usage not equal to desired_cache value
             """
             # to avoid cache cleaning - just create new template
-            name = 'can_i/suport_cache_settings{}'.format(suffix)
+            name = 'can_i/suport_cache_settings%s' % suffix
             self.assertRaises(
                 EmailTemplate.DoesNotExist, get_email_template, name
             )

--- a/post_office/utils.py
+++ b/post_office/utils.py
@@ -50,7 +50,10 @@ def get_email_template(name, language=''):
     """
     Function that returns an email template instance, from cache or DB.
     """
-    if hasattr(settings, 'POST_OFFICE_CACHE') and settings.POST_OFFICE_TEMPLATE_CACHE is False:
+    use_cache = getattr(settings, 'POST_OFFICE_CACHE', True)
+    if use_cache:
+        use_cache = getattr(settings, 'POST_OFFICE_TEMPLATE_CACHE', True)
+    if not use_cache:
         return EmailTemplate.objects.get(name=name, language=language)
     else:
         composite_name = '%s:%s' % (name, language)


### PR DESCRIPTION
before you need to set both variables, first to anything, and second to False, to avoid caching. Now any variable, set to False, will stop cache. It's useful when you are having json-backed cache backend, which just can't save EmailTemplate model without special actions.

To test it manually update test_settings.py to different values of these variables and run tests, and see how and when they fail.