### PR TITLE
Changed choices for language field of EmailTemplate model to be dynamic

### DIFF
--- a/post_office/migrations/0004_remove_choices_from_language.py
+++ b/post_office/migrations/0004_remove_choices_from_language.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('post_office', '0003_longer_subject'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='emailtemplate',
+            name='language',
+            field=models.CharField(default='', help_text='Render template in alternative language', max_length=12, blank=True),
+        ),
+    ]

--- a/post_office/models.py
+++ b/post_office/models.py
@@ -166,6 +166,14 @@ class Log(models.Model):
         return text_type(self.date)
 
 
+class EmailTemplateMeta(models.base.ModelBase):
+    def __new__(cls, name, bases, attrs):
+        # Override choices attr
+        cls = models.base.ModelBase.__new__(cls, name, bases, attrs)
+        setattr(cls._meta.get_field('language'), 'choices_', settings.LANGUAGES)
+        return cls
+
+
 @python_2_unicode_compatible
 class EmailTemplate(models.Model):
     """
@@ -182,7 +190,7 @@ class EmailTemplate(models.Model):
         verbose_name=_("Content"), validators=[validate_template_syntax])
     html_content = models.TextField(blank=True,
         verbose_name=_("HTML content"), validators=[validate_template_syntax])
-    language = models.CharField(max_length=12, choices=settings.LANGUAGES,
+    language = models.CharField(max_length=12, choices=[],
         help_text=_("Render template in alternative language"),
         default='', blank=True)
     default_template = models.ForeignKey('self', related_name='translated_templates',


### PR DESCRIPTION
Changed choices for language field of EmailTemplate model to be dynamic and set the default value to [] 
to avoid making false migrations if LANGUAGES settings is changed. 
Related to https://github.com/ui/django-post_office/pull/123#issuecomment-161747378