### PR TITLE
Django deprecated the SubfieldBase class, use models.Field instead (closes #150)

### DIFF
--- a/post_office/fields.py
+++ b/post_office/fields.py
@@ -1,12 +1,11 @@
-from django.db.models import TextField, SubfieldBase
+from django import forms
 from django.utils import six
-from django.utils.six import with_metaclass
 from django.utils.translation import ugettext_lazy as _
 
 from .validators import validate_comma_separated_emails
 
 
-class CommaSeparatedEmailField(with_metaclass(SubfieldBase, TextField)):
+class CommaSeparatedEmailField(forms.Field):
     default_validators = [validate_comma_separated_emails]
     description = _("Comma-separated emails")
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name='django-post_office',
-    version='2.0.7',
+    version='2.0.8',
     author='Selwin Ong',
     author_email='selwin.ong@gmail.com',
     packages=['post_office'],


### PR DESCRIPTION
PR to solve issue #150.

Solves the warning message shown in the console:

```
lib/python2.7/site-packages/django/utils/six.py:808:  RemovedInDjango110Warning: SubfieldBase has been deprecated. Use Field.from_db_value instead.
```