### PR TITLE
SubfieldBase has been deprecated. Use Field.from_db_value instead.

### DIFF
--- a/post_office/apps.py
+++ b/post_office/apps.py
@@ -4,3 +4,6 @@ from django.apps import AppConfig
 class PostOfficeConfig(AppConfig):
     name = 'post_office'
     verbose_name = "Post Office"
+
+    def ready(self):
+        import post_office.signals

--- a/post_office/fields.py
+++ b/post_office/fields.py
@@ -9,6 +9,16 @@ class CommaSeparatedEmailField(TextField):
     default_validators = [validate_comma_separated_emails]
     description = _("Comma-separated emails")
 
+    @staticmethod
+    def parse_value(value):
+        if isinstance(value, six.string_types):
+            if value == '':
+                return []
+            else:
+                return [s.strip() for s in value.split(',')]
+        else:
+            return value
+
     def __init__(self, *args, **kwargs):
         kwargs['blank'] = True
         super(CommaSeparatedEmailField, self).__init__(*args, **kwargs)
@@ -38,14 +48,11 @@ class CommaSeparatedEmailField(TextField):
     def from_db_value(self, value, expression, connection, context):
         return self.to_python(value)
 
+    def from_db_value(self, value, expression, connection, context):
+        return self.parse_value(value)
+
     def to_python(self, value):
-        if isinstance(value, six.string_types):
-            if value == '':
-                return []
-            else:
-                return [s.strip() for s in value.split(',')]
-        else:
-            return value
+        return self.parse_value(value)
 
     def south_field_triple(self):
         """

--- a/post_office/fields.py
+++ b/post_office/fields.py
@@ -46,9 +46,6 @@ class CommaSeparatedEmailField(TextField):
             return ', '.join(map(lambda s: s.strip(), value))
 
     def from_db_value(self, value, expression, connection, context):
-        return self.to_python(value)
-
-    def from_db_value(self, value, expression, connection, context):
         return self.parse_value(value)
 
     def to_python(self, value):

--- a/post_office/fields.py
+++ b/post_office/fields.py
@@ -1,12 +1,11 @@
-from django.db.models import TextField, SubfieldBase
+from django.db.models import TextField
 from django.utils import six
-from django.utils.six import with_metaclass
 from django.utils.translation import ugettext_lazy as _
 
 from .validators import validate_comma_separated_emails
 
 
-class CommaSeparatedEmailField(with_metaclass(SubfieldBase, TextField)):
+class CommaSeparatedEmailField(TextField):
     default_validators = [validate_comma_separated_emails]
     description = _("Comma-separated emails")
 
@@ -35,6 +34,9 @@ class CommaSeparatedEmailField(with_metaclass(SubfieldBase, TextField)):
             return value
         else:
             return ', '.join(map(lambda s: s.strip(), value))
+
+    def from_db_value(self, value, expression, connection, context):
+        return self.to_python(value)
 
     def to_python(self, value):
         if isinstance(value, six.string_types):

--- a/post_office/models.py
+++ b/post_office/models.py
@@ -232,3 +232,12 @@ class Attachment(models.Model):
 
     def __str__(self):
         return self.name
+
+
+# For backwards compatiblity
+# Django < 1.7 does not support apps.py and therefore not App.ready()
+# where the signals module should be imported.
+
+import django
+if django.VERSION < (1, 7):
+    import signals

--- a/post_office/models.py
+++ b/post_office/models.py
@@ -240,4 +240,4 @@ class Attachment(models.Model):
 
 import django
 if django.VERSION < (1, 7):
-    import signals
+    import post_office.signals

--- a/post_office/signals.py
+++ b/post_office/signals.py
@@ -8,6 +8,6 @@ from .fields import CommaSeparatedEmailField
 
 @receiver(post_init, sender=Email)
 def on_email_post_init(sender, instance, **kwargs):
-    for field in {"to", "cc", "bcc"}:
+    for field in ("to", "cc", "bcc"):
         value = CommaSeparatedEmailField.parse_value(getattr(instance, field))
         setattr(instance, field, value)

--- a/post_office/signals.py
+++ b/post_office/signals.py
@@ -1,0 +1,13 @@
+
+from django.db.models.signals import post_init
+from django.dispatch import receiver
+
+from .models import Email
+from .fields import CommaSeparatedEmailField
+
+
+@receiver(post_init, sender=Email)
+def on_email_post_init(sender, instance, **kwargs):
+    for field in {"to", "cc", "bcc"}:
+        value = CommaSeparatedEmailField.parse_value(getattr(instance, field))
+        setattr(instance, field, value)


### PR DESCRIPTION
Should fix issue #150.

`from_db_value` turns a database value into a Python object
`to_python` is called during form.clean()