### PR TITLE
Use Tox for tests with different python and django version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 *.pyc
 post_office_attachments
+.tox
+*.egg-info

--- a/README.rst
+++ b/README.rst
@@ -562,6 +562,13 @@ To run the test suite::
 
     `which django-admin.py` test post_office --settings=post_office.test_settings --pythonpath=.
 
+To run slow test against different Django and Python versions::
+    
+    pip install tox
+    tox
+
+You can ignore errors about not installed python versions, but it's good to have at least single python2 and single python3. CI server (travis-ci) will have all of them and do basically the same when you create pull request.
+
 
 Changelog
 =========

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,37 @@
+# Tox (http://tox.testrun.org/) is a tool for running tests
+# in multiple virtualenvs. This configuration file will run the
+# test suite on all supported python versions. To use it, "pip install tox"
+# and then run "tox" from this directory.
+
+[tox]
+envlist =
+    py26-django{1.4,1.5,1.6}
+    py27-django{1.4,1.5,1.6,1.7,1.8,1.9}
+    py33-django{1.5,1.6,1.7,1.8}
+    py34-django{1.5,1.6,1.7,1.8,1.9}
+    py35-django{1.8,1.9}
+
+[testenv]
+commands = django-admin.py test post_office --settings=post_office.test_settings
+
+basepython =
+    py26: python2.6
+    py27: python2.7
+    py33: python3.3
+    py34: python3.4
+    py35: python3.5
+
+deps =
+    django-jsonfield
+    django1.4: django>=1.4,<1.5
+    django1.5: django>=1.5,<1.6
+    django1.6: django>=1.6,<1.7
+    django1.7: django>=1.7,<1.8
+    django1.8: django>=1.8,<1.9
+    django1.9: django>=1.9,<1.10
+
+setenv=
+    PYTHONDONTWRITEBYTECODE=1
+
+skipsdist=True
+usedevelop=True


### PR DESCRIPTION
Allows people to run tests old-style, as usual, with current python and django version, or use tox automation project to check against different ones. Especially useful for trying things in python 2 if you use python3 and vise versa.