### PR TITLE
Fix tests for Django 1.10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ python:
 env:
   - DJANGO=1.8
   - DJANGO=1.9
+  - DJANGO=1.10
 
 matrix:
   exclude:

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,9 @@ matrix:
   exclude:
     - python: "3.3"
       env: DJANGO=1.9
+    - python: "3.3"
+      env: DJANGO=1.10
+
 before_install:
   # Workaround for a permissions issue with Travis virtual machine images
   # that breaks Python's multiprocessing:

--- a/README.rst
+++ b/README.rst
@@ -18,7 +18,7 @@ Some awesome features are:
 Dependencies
 ============
 
-* `django >= 1.4 <http://djangoproject.com/>`_
+* `django >= 1.8 <http://djangoproject.com/>`_
 * `django-jsonfield <https://github.com/bradjasper/django-jsonfield>`_
 
 

--- a/README.rst
+++ b/README.rst
@@ -18,7 +18,7 @@ Some awesome features are:
 Dependencies
 ============
 
-* `django >= 1.8 <http://djangoproject.com/>`_
+* `django >= 1.4 <http://djangoproject.com/>`_
 * `django-jsonfield <https://github.com/bradjasper/django-jsonfield>`_
 
 

--- a/post_office/management/commands/cleanup_mail.py
+++ b/post_office/management/commands/cleanup_mail.py
@@ -1,5 +1,4 @@
 import datetime
-from optparse import make_option
 
 from django.core.management.base import BaseCommand
 from django.utils.timezone import now
@@ -9,10 +8,13 @@ from ...models import Email
 
 class Command(BaseCommand):
     help = 'Place deferred messages back in the queue.'
-    option_list = BaseCommand.option_list + (
-        make_option('-d', '--days', type='int', default=90,
-            help="Cleanup mails older than this many days, defaults to 90."),
-    )
+
+    def add_arguments(self, parser):
+        parser.add_argument('-d', '--days',
+            type=int,
+            default=90,
+            help="Cleanup mails older than this many days, defaults to 90."
+            )
 
     def handle(self, verbosity, days, **options):
         # Delete mails and their related logs and queued created before X days

--- a/post_office/management/commands/send_queued_mail.py
+++ b/post_office/management/commands/send_queued_mail.py
@@ -15,18 +15,17 @@ default_lockfile = tempfile.gettempdir() + "/post_office"
 class Command(BaseCommand):
     def add_arguments(self, parser):
         parser.add_argument('-p', '--processes',
-            type='int',
+            type=int,
+            default=1,
             help='Number of processes used to send emails',
-            default=1
             )
         parser.add_argument('-L', '--lockfile',
-            type='string',
             default=default_lockfile,
-            help='Absolute path of lockfile to acquire'
+            help='Absolute path of lockfile to acquire',
             )
         parser.add_argument('-l', '--log-level',
-            type='int',
-            help='"0" to log nothing, "1" to only log errors'
+            type=int,
+            help='"0" to log nothing, "1" to only log errors',
             )
 
     def handle(self, *args, **options):

--- a/post_office/management/commands/send_queued_mail.py
+++ b/post_office/management/commands/send_queued_mail.py
@@ -1,6 +1,5 @@
 import tempfile
 import sys
-from optparse import make_option
 
 from django.core.management.base import BaseCommand
 
@@ -14,15 +13,21 @@ default_lockfile = tempfile.gettempdir() + "/post_office"
 
 
 class Command(BaseCommand):
-
-    option_list = BaseCommand.option_list + (
-        make_option('-p', '--processes', type='int',
-                    help='Number of processes used to send emails', default=1),
-        make_option('-L', '--lockfile', type='string', default=default_lockfile,
-                    help='Absolute path of lockfile to acquire'),
-        make_option('-l', '--log-level', type='int',
-                    help='"0" to log nothing, "1" to only log errors'),
-    )
+    def add_arguments(self, parser):
+        parser.add_argument('-p', '--processes',
+            type='int',
+            help='Number of processes used to send emails',
+            default=1
+            )
+        parser.add_argument('-L', '--lockfile',
+            type='string',
+            default=default_lockfile,
+            help='Absolute path of lockfile to acquire'
+            )
+        parser.add_argument('-l', '--log-level',
+            type='int',
+            help='"0" to log nothing, "1" to only log errors'
+            )
 
     def handle(self, *args, **options):
         logger.info('Acquiring lock for sending queued emails at %s.lock' %

--- a/post_office/test_settings.py
+++ b/post_office/test_settings.py
@@ -54,3 +54,22 @@ MIDDLEWARE_CLASSES = (
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
 )
+
+TEMPLATES = [
+    {
+        'BACKEND': 'django.template.backends.django.DjangoTemplates',
+        'DIRS': [],
+        'APP_DIRS': True,
+        'OPTIONS': {
+            'context_processors': [
+                'django.contrib.auth.context_processors.auth',
+                'django.template.context_processors.debug',
+                'django.template.context_processors.i18n',
+                'django.template.context_processors.media',
+                'django.template.context_processors.static',
+                'django.template.context_processors.tz',
+                'django.contrib.messages.context_processors.messages',
+            ],
+        },
+    },
+]

--- a/tox.ini
+++ b/tox.ini
@@ -2,6 +2,7 @@
 envlist =
     {py27,py34,py35}-django18,
     {py27,py34,py35}-django19
+    {py27,py34,py35}-django110
 
 setenv =
     PYTHONPATH = {toxinidir}:{toxinidir}/tests/
@@ -11,6 +12,7 @@ deps =
   jsonfield
   django18: Django >= 1.8, < 1.9
   django19: Django >= 1.9, < 1.10
+  django110: Django >= 1.10
 
 commands =
   python -V


### PR DESCRIPTION
This PR should cover #168 and get `django-post-office` working with Django 1.10.
 
### This PR consists of:

- adding Django 1.10 to CI 
- adding Django 1.10 `tox.ini` file.
- adds `TEMPLATES` to the test settings.
- Replaces the use of `optparse` in the management commands

### Outstanding questions

I have a few questions I would some input on:

- Should I update the docs to reflect the supported versions of Django?
- Should I squash commits?