### PR TITLE
pin Django 1.10

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -12,7 +12,7 @@ deps =
   jsonfield
   django18: Django >= 1.8, < 1.9
   django19: Django >= 1.9, < 1.10
-  django110: Django >= 1.10
+  django110: Django >= 1.10, < 1.11
 
 commands =
   python -V


### PR DESCRIPTION
It makes sense to pin 1.10 like 1.8 and 1.9 are.

The Django roadmap indicates that there will be a Django 1.11 release April 2017. 

https://www.djangoproject.com/weblog/2015/jun/25/roadmap/