### PR TITLE
Filelock problem with Celery/Docker

### DIFF
--- a/post_office/models.py
+++ b/post_office/models.py
@@ -109,6 +109,7 @@ class Email(models.Model):
 
         for attachment in self.attachments.all():
             msg.attach(attachment.name, attachment.file.read())
+            attachment.file.close()
 
         return msg
 


### PR DESCRIPTION
Hi, 
i have a problem with the attached files.
The files are locked after i call  `mail.send_queued()` in a celery task so i can't remove them (filelock).
i have locked in the `model.py` code and for some reason the `msg.attach(attachment.name, attachment.file.read())` locks the attachment file?!
After adding `attachment.file.close()` the problem is solved.

I stumbled upon it because i want to remove the attached files of sent mails cause i already have these files stored with a filefield in another model and don't wan't duplicate files on the disk.

In my view i can schedule the mail with a specific time and queue them, i'm using the `mail.send` command and after that post_office creates the a new file for each attachment.

What's the best solution for that case? Or is it possible to reuse my existing filefiled from my model for the attachment?


cheers


