### PR TITLE
Fixes for Django 2.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,15 +12,20 @@ env:
   - DJANGO=1.9
   - DJANGO=1.10
   - DJANGO=1.11
+  - DJANGO=2.0
 
 matrix:
   exclude:
+    - python: "2.7"
+      env: DJANGO=2.0
     - python: "3.3"
       env: DJANGO=1.9
     - python: "3.3"
       env: DJANGO=1.10
     - python: "3.3"
       env: DJANGO=1.11
+    - python: "3.3"
+      env: DJANGO=2.0
 
 before_install:
   # Workaround for a permissions issue with Travis virtual machine images

--- a/post_office/admin.py
+++ b/post_office/admin.py
@@ -78,11 +78,11 @@ class SubjectField(TextInput):
         self.attrs.update({'style': 'width: 610px;'})
 
 class EmailTemplateAdminForm(forms.ModelForm):
- 
-    language = forms.ChoiceField(choices=settings.LANGUAGES, required=False, 
+
+    language = forms.ChoiceField(choices=settings.LANGUAGES, required=False,
                                  help_text=_("Render template in alternative language"),
                                  label=_("Language"))
- 
+
     class Meta:
         model = EmailTemplate
         fields = ('name', 'description', 'subject',

--- a/post_office/migrations/0001_initial.py
+++ b/post_office/migrations/0001_initial.py
@@ -72,7 +72,7 @@ class Migration(migrations.Migration):
                 ('status', models.PositiveSmallIntegerField(choices=[(0, 'sent'), (1, 'failed')])),
                 ('exception_type', models.CharField(max_length=255, blank=True)),
                 ('message', models.TextField()),
-                ('email', models.ForeignKey(related_name='logs', editable=False, to='post_office.Email')),
+                ('email', models.ForeignKey(related_name='logs', editable=False, on_delete=models.deletion.CASCADE, to='post_office.Email', )),
             ],
             options={
             },
@@ -81,7 +81,7 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='email',
             name='template',
-            field=models.ForeignKey(blank=True, to='post_office.EmailTemplate', null=True),
+            field=models.ForeignKey(blank=True, on_delete=models.deletion.SET_NULL, to='post_office.EmailTemplate', null=True),
             preserve_default=True,
         ),
         migrations.AddField(

--- a/post_office/migrations/0002_add_i18n_and_backend_alias.py
+++ b/post_office/migrations/0002_add_i18n_and_backend_alias.py
@@ -25,7 +25,7 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='emailtemplate',
             name='default_template',
-            field=models.ForeignKey(related_name='translated_templates', default=None, to='post_office.EmailTemplate', null=True),
+            field=models.ForeignKey(related_name='translated_templates', default=None, to='post_office.EmailTemplate', null=True, on_delete=models.deletion.SET_NULL),
         ),
         migrations.AddField(
             model_name='emailtemplate',

--- a/post_office/test_settings.py
+++ b/post_office/test_settings.py
@@ -1,6 +1,9 @@
 # -*- coding: utf-8 -*-
 
 
+import django
+from distutils.version import StrictVersion
+
 DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.sqlite3',
@@ -50,10 +53,16 @@ ROOT_URLCONF = 'post_office.test_urls'
 
 DEFAULT_FROM_EMAIL = 'webmaster@example.com'
 
-MIDDLEWARE_CLASSES = (
-    'django.contrib.sessions.middleware.SessionMiddleware',
-    'django.contrib.auth.middleware.AuthenticationMiddleware',
-)
+if StrictVersion(str(django.get_version())) < '1.10':
+    MIDDLEWARE_CLASSES = (
+        'django.contrib.sessions.middleware.SessionMiddleware',
+        'django.contrib.auth.middleware.AuthenticationMiddleware',
+    )
+else:
+    MIDDLEWARE = [
+        'django.contrib.sessions.middleware.SessionMiddleware',
+        'django.contrib.auth.middleware.AuthenticationMiddleware',
+    ]
 
 TEMPLATES = [
     {

--- a/post_office/test_urls.py
+++ b/post_office/test_urls.py
@@ -1,7 +1,6 @@
-from django.conf.urls import include, url
+from django.conf.urls import url
 from django.contrib import admin
-admin.autodiscover()
 
 urlpatterns = [
-    url(r'^admin/', include(admin.site.urls), name='admin'),
+    url(r'^admin/', admin.site.urls),
 ]

--- a/post_office/tests/test_views.py
+++ b/post_office/tests/test_views.py
@@ -1,7 +1,11 @@
 from django.contrib.auth.models import User
-from django.core.urlresolvers import reverse
 from django.test.client import Client
 from django.test import TestCase
+
+try:
+    from django.urls import reverse
+except ImportError:
+    from django.core.urlresolvers import reverse
 
 from post_office import mail
 from post_office.models import Email

--- a/tox.ini
+++ b/tox.ini
@@ -3,6 +3,7 @@ envlist =
     {py27,py3.3,py34,py35}-django18,
     {py27,py34,py35}-django{19,110}
     {py27,py34,py35,py36}-django111
+    {py34,py35,py36}-django20
 
 setenv =
     PYTHONPATH = {toxinidir}:{toxinidir}/tests/
@@ -14,6 +15,7 @@ deps =
   django19: Django >= 1.9, < 1.10
   django110: Django >= 1.10, < 1.11
   django111: Django >= 1.11, < 2.0
+  django20: Django >= 2.0, < 2.1
 
 commands =
   python -V


### PR DESCRIPTION
- Addresses #213 
- Keeps Django 1.8 compatibility
- Updated Travis and Tox config to run against Django 2.0
- Updated test settings to deal with deprecated MIDDLEWARE_CLASSES
setting in 2.0
- Updated migrations that were failing in 2.0 to include on_delete
option which addresses #216 