### PR TITLE
Switch to a better implementation of JSONField

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ setup(
     zip_safe=False,
     include_package_data=True,
     package_data={'': ['README.rst']},
-    install_requires=['django>=1.8', 'jsonfield'],
+    install_requires=['django>=1.8', 'django-jsonfield'],
     classifiers=[
         'Development Status :: 5 - Production/Stable',
         'Environment :: Web Environment',

--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,7 @@ setenv =
 
 [testenv]
 deps =
-  jsonfield
+  django-jsonfield
   django18: Django >= 1.8, < 1.9
   django19: Django >= 1.9, < 1.10
   django110: Django >= 1.10, < 1.11


### PR DESCRIPTION
There are two similar implementations of JSONField.
Django Post Office uses the first one.

1. Maintainer: Dan Koch
   Source: https://github.com/dmkoch/django-jsonfield
   Current Version: 2.0.2
   PyPI: https://pypi.python.org/pypi/jsonfield

2. Maintainer: Matthew Schinckel
   Source: https://bitbucket.org/schinckel/django-jsonfield
   Current version: 1.0.1
   PyPI: https://pypi.python.org/pypi/django-jsonfield

Both packages are installed into `jsonfield` directory and have the
same API.
However JSONField by Dan Koch doesn't work correctly with
`django.utils.model_to_dict` - it returns dumped JSON string
representation, instead of object.

Here is the code responsible for this [mis]behavior:

https://github.com/dmkoch/django-jsonfield/blob/master/jsonfield/fields.py#L110

```
    def value_from_object(self, obj, dump=True):
        value = super(JSONFieldBase, self).value_from_object(obj)
        if self.null and value is None:
            return None
        return self.dumps_for_display(value) if dump else value
```

It dumps value by default, while model_to_dict expects it
to return value unchanged.

JSONField by Matthew Schinckel doesn't override `value_from_object`
and works as Django expects.