### PR TITLE
Add test to check that missing file does not crash cleanup attachments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,5 +35,6 @@ ghostdriver.log
 ## generic files to ignore
 *~
 *.lock
+.mypy_cache
 
 post_office_attachments


### PR DESCRIPTION
As per our chat, this addition tests that the condition where the actual file for the attachment is missing, the cleanup command will not crash

Fix #236