### PR TITLE
Catch ValueError when trying to read lockfile

### DIFF
--- a/post_office/lockfile.py
+++ b/post_office/lockfile.py
@@ -48,6 +48,9 @@ class FileLock(object):
             # 2. Symbolic link is not there
             # In either case, we can safely release the lock
             self.release()
+        except ValueError:
+            # most likely an empty or otherwise invalid lock file
+            self.release()
 
     def valid_lock(self):
         """


### PR DESCRIPTION
We're not sure why exactly, but at thinkeasy.net we have occasionally seen an error trying to `int` the contents of the lock file because it's empty. I thought this might be a helpful addition. 
