### PR TITLE
add highlighting for email templates

### DIFF
--- a/post_office/templates/admin/post_office/EmailTemplate/change_form.html
+++ b/post_office/templates/admin/post_office/EmailTemplate/change_form.html
@@ -1,0 +1,34 @@
+{% extends "admin/change_form.html" %}
+
+{% block extrahead %}
+    {{ block.super }}
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.40.2/codemirror.min.css"
+          integrity="sha256-I8NyGs4wjbMuBSUE40o55W6k6P7tu/7G28/JGUUYCIs=" crossorigin="anonymous"/>
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.40.2/theme/mdn-like.min.css"
+          integrity="sha256-NOY3wYv+L8FgjrwUjZgi4StO4CvnI8F+NxQwFhhstH8=" crossorigin="anonymous"/>
+{% endblock %}
+
+{% block admin_change_form_document_ready %}
+    {{ block.super }}
+
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.40.2/codemirror.min.js"
+            integrity="sha256-hY4lHTn7c3QSwGpgxj3OAYynw9Etpx530BNJHTmhvYA=" crossorigin="anonymous"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.40.2/addon/mode/overlay.min.js"
+            integrity="sha256-pmk+B8h8zI8asluOrjNTCKvDypYYKOYVmvmhwPDaYl0=" crossorigin="anonymous"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.40.2/mode/django/django.min.js"
+            integrity="sha256-nLr6+psgWgm4BnA7O+W9T0gldFRHCI+H3cByx/TSabE=" crossorigin="anonymous"></script>
+
+    <script>
+        var options = {
+            mode: 'django',
+            theme: "mdn-like",
+            lineWrapping: true
+        };
+
+        CodeMirror.fromTextArea($('#id_subject')[0], options);
+        CodeMirror.fromTextArea($('#id_content')[0], options);
+        CodeMirror.fromTextArea($('#id_html_content')[0], options);
+
+        $('.CodeMirror').css('height', 'auto');
+    </script>
+{% endblock %}


### PR DESCRIPTION
A small modification to the admin change_form to add syntax highlighting to subject, content and html_content:

![screen shot 2018-10-01 at 16 37 00](https://user-images.githubusercontent.com/2007875/46298982-4c439b00-c598-11e8-8250-317b0895d308.png)

Not sure if this is the best way to do it, perhaps Form.Media would be better?