### PR TITLE
Update CommaSeparatedEmailWidget method override name

### DIFF
--- a/post_office/admin.py
+++ b/post_office/admin.py
@@ -31,7 +31,7 @@ class CommaSeparatedEmailWidget(TextInput):
         super(CommaSeparatedEmailWidget, self).__init__(*args, **kwargs)
         self.attrs.update({'class': 'vTextField'})
 
-    def _format_value(self, value):
+    def format_value(self, value):
         # If the value is a string wrap it in a list so it does not get sliced.
         if not value:
             return ''


### PR DESCRIPTION
The initial name of the method override (`_format_value`) appears to have been incorrectly named. It should be `format_value`

See https://github.com/django/django/blob/master/django/forms/widgets.py#L205