### PR TITLE
Added a check to see if platform is Windows

### DIFF
--- a/post_office/lockfile.py
+++ b/post_office/lockfile.py
@@ -20,6 +20,7 @@
 
 import os
 import time
+import platform
 
 
 class FileLocked(Exception):
@@ -122,7 +123,7 @@ class FileLock(object):
         os.write(pid_file, str(os.getpid()).encode('utf-8'))
         os.close(pid_file)
 
-        if hasattr(os, 'symlink'):
+        if hasattr(os, 'symlink') and platform.system() != 'Windows':
             os.symlink(self.pid_filename, self.lock_filename)
         else:
             # Windows platforms doesn't support symlinks, at least not through the os API


### PR DESCRIPTION
Your 'lockfile.py' has a condition that if the os library of python has attribute 'symlink' then you are trying to create a symlink and clearly in the other condition you have mentioned, it is not supported in Windows. But the OS library in python on Windows does have an attribute 'symlink' but when I try to connect it does not work, as expected. So I have added an additional check to see if the platform is Windows or not. 