### PR TITLE
Prevent the need for updating VERSION on two different places

### DIFF
--- a/post_office/__init__.py
+++ b/post_office/__init__.py
@@ -1,5 +1,3 @@
 VERSION = (3, 2, 1)
 
-from .backends import EmailBackend
-
 default_app_config = 'post_office.apps.PostOfficeConfig'

--- a/post_office/settings.py
+++ b/post_office/settings.py
@@ -42,7 +42,7 @@ def get_available_backends():
 
     # If EMAIL_BACKEND is set to use PostOfficeBackend
     # and POST_OFFICE_BACKEND is not set, fall back to SMTP
-    if 'post_office.EmailBackend' in backends['default']:
+    if 'post_office.backends.EmailBackend' in backends['default']:
         backends['default'] = 'django.core.mail.backends.smtp.EmailBackend'
 
     return backends

--- a/post_office/tests/test_backends.py
+++ b/post_office/tests/test_backends.py
@@ -23,7 +23,7 @@ class ErrorRaisingBackend(BaseEmailBackend):
 
 class BackendTest(TestCase):
 
-    @override_settings(EMAIL_BACKEND='post_office.EmailBackend')
+    @override_settings(EMAIL_BACKEND='post_office.backends.EmailBackend')
     def test_email_backend(self):
         """
         Ensure that email backend properly queue email messages.
@@ -51,7 +51,7 @@ class BackendTest(TestCase):
         self.assertEqual(get_backend(), 'django.core.mail.backends.smtp.EmailBackend')
 
         # If EMAIL_BACKEND is set to PostOfficeBackend, use SMTP to send by default
-        setattr(settings, 'EMAIL_BACKEND', 'post_office.EmailBackend')
+        setattr(settings, 'EMAIL_BACKEND', 'post_office.backends.EmailBackend')
         self.assertEqual(get_backend(), 'django.core.mail.backends.smtp.EmailBackend')
 
         # If EMAIL_BACKEND is set on new dictionary-styled settings, use that
@@ -65,7 +65,7 @@ class BackendTest(TestCase):
             delattr(settings, 'EMAIL_BACKEND')
         setattr(settings, 'POST_OFFICE', previous_settings)
 
-    @override_settings(EMAIL_BACKEND='post_office.EmailBackend')
+    @override_settings(EMAIL_BACKEND='post_office.backends.EmailBackend')
     def test_sending_html_email(self):
         """
         "text/html" attachments to Email should be persisted into the database
@@ -77,7 +77,7 @@ class BackendTest(TestCase):
         email = Email.objects.latest('id')
         self.assertEqual(email.html_message, 'html')
 
-    @override_settings(EMAIL_BACKEND='post_office.EmailBackend')
+    @override_settings(EMAIL_BACKEND='post_office.backends.EmailBackend')
     def test_headers_sent(self):
         """
         Test that headers are correctly set on the outgoing emails.
@@ -89,7 +89,7 @@ class BackendTest(TestCase):
         email = Email.objects.latest('id')
         self.assertEqual(email.headers, {'Reply-To': 'reply@example.com'})
 
-    @override_settings(EMAIL_BACKEND='post_office.EmailBackend')
+    @override_settings(EMAIL_BACKEND='post_office.backends.EmailBackend')
     def test_backend_attachments(self):
         message = EmailMessage('subject', 'body', 'from@example.com',
                                ['recipient@example.com'])
@@ -102,7 +102,7 @@ class BackendTest(TestCase):
         self.assertEqual(email.attachments.all()[0].name, 'attachment.txt')
         self.assertEqual(email.attachments.all()[0].file.read(), b'attachment content')
 
-    @override_settings(EMAIL_BACKEND='post_office.EmailBackend')
+    @override_settings(EMAIL_BACKEND='post_office.backends.EmailBackend')
     def test_backend_image_attachments(self):
         message = EmailMessage('subject', 'body', 'from@example.com',
                                ['recipient@example.com'])
@@ -123,7 +123,7 @@ class BackendTest(TestCase):
         self.assertEqual(email.attachments.all()[0].headers.get('Content-Disposition'), 'inline; filename="dummy.png"')
 
     @override_settings(
-        EMAIL_BACKEND='post_office.EmailBackend',
+        EMAIL_BACKEND='post_office.backends.EmailBackend',
         POST_OFFICE={
             'DEFAULT_PRIORITY': 'now',
             'BACKENDS': {'default': 'django.core.mail.backends.dummy.EmailBackend'}

--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,7 @@
 import sys
 from setuptools import setup
 from setuptools.command.test import test as TestCommand
+from post_office import VERSION
 
 
 class Tox(TestCommand):
@@ -31,7 +32,7 @@ TESTS_REQUIRE = ['tox >= 2.3']
 
 setup(
     name='django-post_office',
-    version='3.2.0',
+    version='.'.join(str(v) for v in VERSION),
     author='Selwin Ong',
     author_email='selwin.ong@gmail.com',
     packages=['post_office'],


### PR DESCRIPTION
In my projects, I prefer to keep only one location which has to be updated on version jumps. Currently it is in 'post_office/__init__.py' and 'post_office/setup.py'.

However, this requires to remove the `from .backends import EmailBackend` from the `__init__.py` file. 
@selwin please tell my if this is OK for you. 