### PR TITLE
Update README supported Django versions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -19,7 +19,7 @@ Some awesome features are:
 Dependencies
 ============
 
-* `django >= 1.8 <http://djangoproject.com/>`_
+* `django >= 1.10 <http://djangoproject.com/>`_
 * `django-jsonfield <https://github.com/bradjasper/django-jsonfield>`_
 
 


### PR DESCRIPTION
The changelog notes under version 3.2.0 "Drop support for Django-1.8 and 1.9." however this seems to have been missed in the README.