### PR TITLE
Add EMAIL_TEST_MODE settings to allow email redirection in developeme…

### DIFF
--- a/post_office/backends.py
+++ b/post_office/backends.py
@@ -2,6 +2,7 @@ from collections import OrderedDict
 from email.mime.base import MIMEBase
 from django.core.files.base import ContentFile
 from django.core.mail.backends.base import BaseEmailBackend
+from django.conf import settings
 
 from .settings import get_default_priority
 
@@ -51,6 +52,10 @@ class EmailBackend(BaseEmailBackend):
                 else:
                     attachment_files[attachment[0]] = ContentFile(attachment[1])
 
+            # If EMAIL_TEST_MODE is in settings.py all email are redirect
+            test_email = getattr(settings, 'EMAIL_TEST_MODE', False)
+            if test_email:
+                email_message.to = email
             email = create(sender=from_email,
                            recipients=email_message.to, cc=email_message.cc,
                            bcc=email_message.bcc, subject=subject,

--- a/post_office/backends.py
+++ b/post_office/backends.py
@@ -55,7 +55,7 @@ class EmailBackend(BaseEmailBackend):
             # If EMAIL_TEST_MODE is in settings.py all email are redirect
             test_email = getattr(settings, 'EMAIL_TEST_MODE', False)
             if test_email:
-                email_message.to = email
+                email_message.to = test_email
             email = create(sender=from_email,
                            recipients=email_message.to, cc=email_message.cc,
                            bcc=email_message.bcc, subject=subject,


### PR DESCRIPTION
If in the settings.py in django project have 
`EMAIL_TEST_MODE = 'toto@gmail.com'`

All mail are redirect to toto@gmail.com

It is a idea from django-yubin project 
https://django-yubin.readthedocs.io/en/latest/settings.html