### PR TITLE
Override recipients settings #277

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -512,6 +512,18 @@ setting ``DEFAULT_PRIORITY``. Integration with asynchronous email backends
         'DEFAULT_PRIORITY': 'now'
     }
 
+Override recipient
+----------------
+
+The default is disabled. If you went redirect all sended mails, for testing mail rendering in developpement period
+
+.. code-block:: python
+
+    # Put this in settings.py
+    POST_OFFICE = {
+        'OBERRIDE_RECIPIENTS': 'to@exemple.com'
+    }
+
 Log Level
 ---------
 

--- a/README.rst
+++ b/README.rst
@@ -521,7 +521,7 @@ The default is disabled. If you went redirect all sended mails, for testing mail
 
     # Put this in settings.py
     POST_OFFICE = {
-        'OVERRIDE_RECIPIENTS': 'to@exemple.com'
+        'OVERRIDE_RECIPIENTS': ['to@exemple.com'] or ['to@exemple.com', 'to2@exemple.com']
     }
 
 Log Level

--- a/README.rst
+++ b/README.rst
@@ -521,7 +521,7 @@ The default is disabled. If you went redirect all sended mails, for testing mail
 
     # Put this in settings.py
     POST_OFFICE = {
-        'OBERRIDE_RECIPIENTS': 'to@exemple.com'
+        'OVERRIDE_RECIPIENTS': 'to@exemple.com'
     }
 
 Log Level

--- a/post_office/models.py
+++ b/post_office/models.py
@@ -19,7 +19,7 @@ from post_office.fields import CommaSeparatedEmailField
 
 from .compat import text_type, smart_text
 from .connections import connections
-from .settings import context_field_class, get_log_level, get_template_engine
+from .settings import context_field_class, get_log_level, get_template_engine, get_override_recipients
 from .validators import validate_email_with_name, validate_template_syntax
 
 
@@ -96,6 +96,11 @@ class Email(models.Model):
         Returns a django ``EmailMessage`` or ``EmailMultiAlternatives`` object,
         depending on whether html_message is empty.
         """
+        if get_override_recipients():
+            print('ici')
+            self.to = [get_override_recipients()]
+            self.save(update_fields=['to'])
+        print("self.to", self.to)
         if self.template is not None:
             engine = get_template_engine()
             subject = engine.from_string(self.template.subject).render(self.context)

--- a/post_office/models.py
+++ b/post_office/models.py
@@ -97,10 +97,9 @@ class Email(models.Model):
         depending on whether html_message is empty.
         """
         if get_override_recipients():
-            print('ici')
             self.to = [get_override_recipients()]
             self.save(update_fields=['to'])
-        print("self.to", self.to)
+
         if self.template is not None:
             engine = get_template_engine()
             subject = engine.from_string(self.template.subject).render(self.context)

--- a/post_office/models.py
+++ b/post_office/models.py
@@ -97,8 +97,7 @@ class Email(models.Model):
         depending on whether html_message is empty.
         """
         if get_override_recipients():
-            self.to = [get_override_recipients()]
-            self.save(update_fields=['to'])
+            self.to = get_override_recipients()
 
         if self.template is not None:
             engine = get_template_engine()

--- a/post_office/settings.py
+++ b/post_office/settings.py
@@ -96,6 +96,10 @@ def get_template_engine():
     return template_engines[using]
 
 
+def get_override_recipients():
+    return get_config().get('OVERRIDE_RECIPIENTS', None)
+
+
 CONTEXT_FIELD_CLASS = get_config().get('CONTEXT_FIELD_CLASS',
                                        'jsonfield.JSONField')
 context_field_class = import_attribute(CONTEXT_FIELD_CLASS)

--- a/post_office/tests/test_models.py
+++ b/post_office/tests/test_models.py
@@ -4,7 +4,7 @@ import os
 
 from datetime import datetime, timedelta
 
-from django.conf import settings as django_settings
+from django.conf import settings as django_settings, settings
 from django.core import mail
 from django.core import serializers
 from django.core.files.base import ContentFile
@@ -73,6 +73,22 @@ class ModelTest(TestCase):
                                      subject='Test dispatch', message='Message', backend_alias='locmem')
         email.dispatch()
         self.assertEqual(mail.outbox[0].subject, 'Test dispatch')
+
+    def test_dispatch_with_override_recipients(self):
+        previous_settings = settings.POST_OFFICE
+        email = Email.objects.create(to=['to@example.com'], from_email='from@example.com',
+                                     subject='Test dispatch', message='Message', backend_alias='locmem')
+        email.dispatch()
+        self.assertEqual(mail.outbox[0].to, ['to@example.com'])
+        print("mail.outbox[0].to", mail.outbox[0].to)
+
+        setattr(settings, 'POST_OFFICE', {'OVERRIDE_RECIPIENTS': 'override@gmail.com'})
+        print(settings.POST_OFFICE)
+        email2 = Email.objects.create(to=['to@example.com'], from_email='from@example.com',
+                                     subject='Test dispatch', message='Message', backend_alias='locmem')
+        email2.dispatch()
+        self.assertEqual(mail.outbox[0].to, ['override@gmail.com'])
+        settings.POST_OFFICE = previous_settings
 
     def test_status_and_log(self):
         """

--- a/post_office/tests/test_models.py
+++ b/post_office/tests/test_models.py
@@ -76,17 +76,10 @@ class ModelTest(TestCase):
 
     def test_dispatch_with_override_recipients(self):
         previous_settings = settings.POST_OFFICE
+        setattr(settings, 'POST_OFFICE', {'OVERRIDE_RECIPIENTS': 'override@gmail.com'})
         email = Email.objects.create(to=['to@example.com'], from_email='from@example.com',
                                      subject='Test dispatch', message='Message', backend_alias='locmem')
         email.dispatch()
-        self.assertEqual(mail.outbox[0].to, ['to@example.com'])
-        print("mail.outbox[0].to", mail.outbox[0].to)
-
-        setattr(settings, 'POST_OFFICE', {'OVERRIDE_RECIPIENTS': 'override@gmail.com'})
-        print(settings.POST_OFFICE)
-        email2 = Email.objects.create(to=['to@example.com'], from_email='from@example.com',
-                                     subject='Test dispatch', message='Message', backend_alias='locmem')
-        email2.dispatch()
         self.assertEqual(mail.outbox[0].to, ['override@gmail.com'])
         settings.POST_OFFICE = previous_settings
 

--- a/post_office/tests/test_models.py
+++ b/post_office/tests/test_models.py
@@ -76,7 +76,7 @@ class ModelTest(TestCase):
 
     def test_dispatch_with_override_recipients(self):
         previous_settings = settings.POST_OFFICE
-        setattr(settings, 'POST_OFFICE', {'OVERRIDE_RECIPIENTS': 'override@gmail.com'})
+        setattr(settings, 'POST_OFFICE', {'OVERRIDE_RECIPIENTS': ['override@gmail.com']})
         email = Email.objects.create(to=['to@example.com'], from_email='from@example.com',
                                      subject='Test dispatch', message='Message', backend_alias='locmem')
         email.dispatch()


### PR DESCRIPTION
Related to #277

If in the settings.py in django project have
```python
POST_OFFICE = {
    'OVERRIDE_RECIPIENTS': 'toto@gmail.com'
}```

All mail are redirect to toto@gmail.com
Option is interesting because it protects and allows developers to test the rendering of emails.

It is a idea from django-yubin project
https://django-yubin.readthedocs.io/en/latest/settings.html