### PR TITLE
Add -x, --exit-after-batch arguments to send_queued_mail command

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -457,6 +457,11 @@ Management Commands
 | ``--lockfile`` or ``-L``  | Full path to file used as lock file. Defaults to |
 |                           | ``/tmp/post_office.lock``                        |
 +---------------------------+--------------------------------------------------+
+| ``--exit-after-batch`` or | Exit the command after sending one batch of      |
+|    ``-x``                 | emails. By combining BATCH_SIZE and crontab,     |
+|                           | you can send emails through servers with small   |
+|                           | throttling values.                               |
++---------------------------+--------------------------------------------------+
 
 
 * ``cleanup_mail`` - delete all emails created before an X number of days

--- a/post_office/management/commands/send_queued_mail.py
+++ b/post_office/management/commands/send_queued_mail.py
@@ -34,6 +34,11 @@ class Command(BaseCommand):
             type=int,
             help='"0" to log nothing, "1" to only log errors',
         )
+        parser.add_argument(
+            '-x', '--exit-after-batch',
+            action='store_true',
+            help='Exit script after sending one batch of emails',
+        )
 
     def handle(self, *args, **options):
         logger.info('Acquiring lock for sending queued emails at %s.lock' %
@@ -52,6 +57,9 @@ class Command(BaseCommand):
 
                     # Close DB connection to avoid multiprocessing errors
                     connection.close()
+
+                    if options.get('exit_after_batch'):
+                        break
 
                     if not Email.objects.filter(status=STATUS.queued) \
                             .filter(Q(scheduled_time__lte=now()) | Q(scheduled_time=None)).exists():


### PR DESCRIPTION
This feature is useful for email servers that have low throttling values. One can configure crontab with proper time interval and appropriate BATCH_SIZE to make sure that all the emails get sent