### PR TITLE
Drop Django < 2.2, switch jsonfield2 back to jsonfield

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,19 +6,19 @@ matrix:
   include:
     # Python 3.5
     - python: 3.5
-      env: TOXENV=py35-django111,py35-django20,py35-django21,py35-django22
+      env: TOXENV=py35-django22
 
     # Python 3.6
     - python: 3.6
-      env: TOXENV=py36-django111,py36-django20,py36-django21,py36-django22,py36-django30
+      env: TOXENV=py36-django22,py36-django30
 
     # Python 3.7
     - python: 3.7
-      env: TOXENV=py37-django20,py37-django21,py37-django22,py37-django30
+      env: TOXENV=py37-django22,py37-django30
 
     # Python 3.8
     - python: 3.8
-      env: TOXENV=py38-django20,py38-django21,py38-django22,py38-django30
+      env: TOXENV=py38-django22,py38-django30
 
     # Django Master
     - python: 3.6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+Version X.X.X
+-------------
+
+* Revert ``jsonfield2`` back to ``jsonfield``, now that it's maintained.
+
 Version 3.3.0
 -------------
 * Support for Django 3.0. Thanks @Mogost!

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Changelog
 Version X.X.X
 -------------
 
+* Drop support for Django < 2.2.
 * Revert ``jsonfield2`` back to ``jsonfield``, now that it's maintained.
 
 Version 3.3.0

--- a/README.rst
+++ b/README.rst
@@ -20,7 +20,7 @@ Dependencies
 ============
 
 * `django >= 1.11 <https://djangoproject.com/>`_
-* `jsonfield2 <https://github.com/rpkilby/jsonfield2>`_
+* `jsonfield <https://github.com/rpkilby/jsonfield>`_
 
 
 Installation

--- a/post_office/fields.py
+++ b/post_office/fields.py
@@ -1,4 +1,3 @@
-import django
 from django.db.models import TextField
 from django.utils.translation import ugettext_lazy as _
 
@@ -22,12 +21,8 @@ class CommaSeparatedEmailField(TextField):
         defaults.update(kwargs)
         return super().formfield(**defaults)
 
-    if django.VERSION < (2, 0):
-        def from_db_value(self, value, expression, connection, context):
-            return self.to_python(value)
-    else:
-        def from_db_value(self, value, expression, connection):
-            return self.to_python(value)
+    def from_db_value(self, value, expression, connection):
+        return self.to_python(value)
 
     def get_prep_value(self, value):
         """

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ setup(
     zip_safe=False,
     include_package_data=True,
     package_data={'': ['README.rst']},
-    install_requires=['django>=1.11', 'jsonfield>=3.0'],
+    install_requires=['django>=2.2', 'jsonfield>=3.0'],
     classifiers=[
         'Development Status :: 5 - Production/Stable',
         'Environment :: Web Environment',

--- a/setup.py
+++ b/setup.py
@@ -41,10 +41,7 @@ setup(
     zip_safe=False,
     include_package_data=True,
     package_data={'': ['README.rst']},
-    install_requires=[
-        'django>=1.11', 
-        'jsonfield2<=3.0.3',  # Remove version freezing after drop support for Django 1.11
-    ],
+    install_requires=['django>=1.11', 'jsonfield>=3.0'],
     classifiers=[
         'Development Status :: 5 - Production/Stable',
         'Environment :: Web Environment',

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,5 @@
 [tox]
 envlist =
-  py{35,36}-django111
-  py{35,36,37}-django20
-  py{35,36,37}-django21
   py{35,36,37}-django22
   py{36,37,38}-django30
   py{36,37,38}-djangomaster
@@ -13,9 +10,6 @@ setenv =
   DJANGO_SETTINGS_MODULE=post_office.test_settings
 
 deps =
-  django111: Django==1.11.*
-  django20: Django==2.0.*
-  django21: Django==2.1.*
   django22: Django==2.2.*
   django30: Django==3.0.*
   djangomaster: https://github.com/django/django/archive/master.tar.gz

--- a/tox.ini
+++ b/tox.ini
@@ -13,7 +13,6 @@ setenv =
   DJANGO_SETTINGS_MODULE=post_office.test_settings
 
 deps =
-  jsonfield2
   django111: Django==1.11.*
   django20: Django==2.0.*
   django21: Django==2.1.*


### PR DESCRIPTION
Hi all. This reverts the move from `jsonfield` to `jsonfield2`, as I've been granted ownership of the project and my fork is no longer needed. 