### PR TITLE
docs: Fix simple typo, manange -> manage

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -120,7 +120,7 @@ This will schedule a task at specific times. Use ``-1`` to signal any time, it c
 in cron.
 
 Please note that ``uwsgidecorators`` are available only, if the application has been started
-with **uWSGI**. However, Django's internal ``./manange.py runserver`` also access this file,
+with **uWSGI**. However, Django's internal ``./manage.py runserver`` also access this file,
 therefore wrap the block into an exception handler as shown above.
 
 This configuration is very useful in environments, such as Docker containers, where you


### PR DESCRIPTION
There is a small typo in README.rst.

Should read `manage` rather than `manange`.

