### PR TITLE
Fix #321: Render Email Templates in proper locale settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+next
+----
+* Fix rendering of email templates in expected locale.
+
+
 Version 3.4.1 (2020-05-16)
 --------------------------
 * Allow `tasks.py` to be imported when Celery is not installed. This allows

--- a/post_office/mail.py
+++ b/post_office/mail.py
@@ -7,6 +7,7 @@ from django.db import connection as db_connection
 from django.db.models import Q
 from django.template import Context, Template
 from django.utils import timezone
+from django.utils.translation import override as translation_override
 
 from .connections import connections
 from .models import Email, EmailTemplate, Log, PRIORITY, STATUS
@@ -58,14 +59,17 @@ def create(sender, recipients=None, cc=None, bcc=None, subject='', message='',
     else:
 
         if template:
+            language = template.language
             subject = template.subject
             message = template.content
             html_message = template.html_content
-
-        _context = Context(context or {})
-        subject = Template(subject).render(_context)
-        message = Template(message).render(_context)
-        html_message = Template(html_message).render(_context)
+        else:
+            language = ''
+        with translation_override(language):
+            _context = Context(context or {})
+            subject = Template(subject).render(_context)
+            message = Template(message).render(_context)
+            html_message = Template(html_message).render(_context)
 
         email = Email(
             from_email=sender,

--- a/post_office/models.py
+++ b/post_office/models.py
@@ -10,6 +10,8 @@ from django.db import models
 from django.utils.encoding import smart_str
 from django.utils.translation import pgettext_lazy, gettext_lazy as _
 from django.utils import timezone
+from django.utils.translation import override as translation_override
+
 from jsonfield import JSONField
 
 from post_office import cache
@@ -100,10 +102,11 @@ class Email(models.Model):
 
         if self.template is not None:
             engine = get_template_engine()
-            subject = engine.from_string(self.template.subject).render(self.context)
-            plaintext_message = engine.from_string(self.template.content).render(self.context)
-            multipart_template = engine.from_string(self.template.html_content)
-            html_message = multipart_template.render(self.context)
+            with translation_override(self.template.language):
+                subject = engine.from_string(self.template.subject).render(self.context)
+                plaintext_message = engine.from_string(self.template.content).render(self.context)
+                multipart_template = engine.from_string(self.template.html_content)
+                html_message = multipart_template.render(self.context)
 
         else:
             subject = smart_str(self.subject)

--- a/post_office/tests/test_mail.py
+++ b/post_office/tests/test_mail.py
@@ -1,4 +1,4 @@
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch
 
 import pytz
 
@@ -249,10 +249,10 @@ class MailTest(TestCase):
         """
         template = EmailTemplate.objects.create(
             subject='Subject {{ name }}',
-            content='Content {{ name }}',
-            html_content='HTML {{ name }}'
+            content='Content {{ name }} Date {{ date }}',
+            html_content='HTML {{ name }} Date {{ date }}'
         )
-        context = {'name': 'test'}
+        context = {'name': 'test', 'date': timezone.datetime(2020, 5, 18)}
         email = send(recipients=['a@example.com', 'b@example.com'],
                      template=template, context=context,
                      render_on_delivery=True)
@@ -346,25 +346,25 @@ class MailTest(TestCase):
 
         template = EmailTemplate.objects.create(
             subject='Subject {{ name }}',
-            content='Content {{ name }}',
-            html_content='HTML {{ name }}'
+            content='Content {{ name }} Date {{ date }}',
+            html_content='HTML {{ name }} Date {{ date }}'
         )
         russian_template = EmailTemplate(
             default_template=template,
             language='ru',
             subject='предмет {{ name }}',
-            content='содержание {{ name }}',
-            html_content='HTML {{ name }}'
+            content='содержание {{ name }} Дата {{ date }}',
+            html_content='HTML {{ name }} Дата {{ date }}'
         )
         russian_template.save()
 
-        context = {'name': 'test'}
+        context = {'name': 'test', 'date': timezone.datetime(2020, 5, 18)}
         email = send(recipients=['to@example.com'], sender='from@example.com',
                      template=template, context=context)
         email = Email.objects.get(id=email.id)
         self.assertEqual(email.subject, 'Subject test')
-        self.assertEqual(email.message, 'Content test')
-        self.assertEqual(email.html_message, 'HTML test')
+        self.assertEqual(email.message, 'Content test Date May 18, 2020, midnight')
+        self.assertEqual(email.html_message, 'HTML test Date May 18, 2020, midnight')
         self.assertEqual(email.context, None)
         self.assertEqual(email.template, None)
 
@@ -373,8 +373,8 @@ class MailTest(TestCase):
                      template=russian_template, context=context)
         email = Email.objects.get(id=email.id)
         self.assertEqual(email.subject, 'предмет test')
-        self.assertEqual(email.message, 'содержание test')
-        self.assertEqual(email.html_message, 'HTML test')
+        self.assertEqual(email.message, 'содержание test Дата Май 18, 2020, полночь')
+        self.assertEqual(email.html_message, 'HTML test Дата Май 18, 2020, полночь')
         self.assertEqual(email.context, None)
         self.assertEqual(email.template, None)
 


### PR DESCRIPTION
This fixes #321  (details are explained there)