### PR TITLE
Add setting for celery.

### DIFF
--- a/post_office/settings.py
+++ b/post_office/settings.py
@@ -80,7 +80,7 @@ def get_batch_size():
 
 
 def get_celery_enabled():
-    return get_config().get('CELERY', True)
+    return get_config().get('CELERY_TASKS_ENABLED', True)
 
 
 def get_threads_per_process():

--- a/post_office/settings.py
+++ b/post_office/settings.py
@@ -79,6 +79,10 @@ def get_batch_size():
     return get_config().get('BATCH_SIZE', 100)
 
 
+def get_celery_enabled():
+    return get_config().get('CELERY', True)
+
+
 def get_threads_per_process():
     return get_config().get('THREADS_PER_PROCESS', 5)
 

--- a/post_office/settings.py
+++ b/post_office/settings.py
@@ -80,7 +80,7 @@ def get_batch_size():
 
 
 def get_celery_enabled():
-    return get_config().get('CELERY_TASKS_ENABLED', True)
+    return get_config().get('CELERY_ENABLED', True)
 
 
 def get_threads_per_process():

--- a/post_office/tasks.py
+++ b/post_office/tasks.py
@@ -5,28 +5,32 @@ from django.utils.timezone import now
 from post_office.mail import send_queued
 from post_office.utils import cleanup_expired_mails
 
+from .settings import get_celery_enabled
+
 # Only define the tasks and handler if we can import celery.
 # This allows the module to be imported in environments without Celery, for
 # example by other task queue systems such as Huey, which use the same pattern
 # of auto-discovering tasks in "tasks" submodules
-try:
-    from celery import shared_task
-except ImportError:
-    pass
-else:
-    @shared_task(ignore_result=True)
-    def send_queued_mail(*args, **kwargs):
-        send_queued()
 
-    def queued_mail_handler(sender, **kwargs):
-        """
-        To be called by post_office.signals.email_queued.send()
-        """
-        send_queued_mail.delay()
+if get_celery_enabled():
+    try:
+        from celery import shared_task
+    except ImportError:
+        pass
+    else:
+        @shared_task(ignore_result=True)
+        def send_queued_mail(*args, **kwargs):
+            send_queued()
 
-    @shared_task(ignore_result=True)
-    def cleanup_mail(*args, **kwargs):
-        days = kwargs.get('days', 90)
-        cutoff_date = now() - datetime.timedelta(days)
-        delete_attachments = kwargs.get('delete_attachments', True)
-        cleanup_expired_mails(cutoff_date, delete_attachments)
+        def queued_mail_handler(sender, **kwargs):
+            """
+            To be called by post_office.signals.email_queued.send()
+            """
+            send_queued_mail.delay()
+
+        @shared_task(ignore_result=True)
+        def cleanup_mail(*args, **kwargs):
+            days = kwargs.get('days', 90)
+            cutoff_date = now() - datetime.timedelta(days)
+            delete_attachments = kwargs.get('delete_attachments', True)
+            cleanup_expired_mails(cutoff_date, delete_attachments)

--- a/post_office/tasks.py
+++ b/post_office/tasks.py
@@ -12,25 +12,27 @@ from .settings import get_celery_enabled
 # example by other task queue systems such as Huey, which use the same pattern
 # of auto-discovering tasks in "tasks" submodules
 
-if get_celery_enabled():
-    try:
+try:
+    if get_celery_enabled():
         from celery import shared_task
-    except ImportError:
-        pass
     else:
-        @shared_task(ignore_result=True)
-        def send_queued_mail(*args, **kwargs):
-            send_queued()
+        raise NotImplementedError()
+except (ImportError, NotImplementedError):
+    pass
+else:
+    @shared_task(ignore_result=True)
+    def send_queued_mail(*args, **kwargs):
+        send_queued()
 
-        def queued_mail_handler(sender, **kwargs):
-            """
-            To be called by post_office.signals.email_queued.send()
-            """
-            send_queued_mail.delay()
+    def queued_mail_handler(sender, **kwargs):
+        """
+        To be called by post_office.signals.email_queued.send()
+        """
+        send_queued_mail.delay()
 
-        @shared_task(ignore_result=True)
-        def cleanup_mail(*args, **kwargs):
-            days = kwargs.get('days', 90)
-            cutoff_date = now() - datetime.timedelta(days)
-            delete_attachments = kwargs.get('delete_attachments', True)
-            cleanup_expired_mails(cutoff_date, delete_attachments)
+    @shared_task(ignore_result=True)
+    def cleanup_mail(*args, **kwargs):
+        days = kwargs.get('days', 90)
+        cutoff_date = now() - datetime.timedelta(days)
+        delete_attachments = kwargs.get('delete_attachments', True)
+        cleanup_expired_mails(cutoff_date, delete_attachments)


### PR DESCRIPTION
As celery doesn't allow to not ignore a task, Put a config for disabled celery even if celery is used.

[+] Add a config for get celery enabled or not (default True)
[+] If celery is not enabled in postoffice settings don't import tasks for postoffice