### PR TITLE
Fixes: #218 SMTPServerDisconnected error

### DIFF
--- a/post_office/models.py
+++ b/post_office/models.py
@@ -183,6 +183,9 @@ class Email(models.Model):
             if not commit:
                 raise
 
+        if disconnect_after_delivery:
+            connections.close()
+
         if commit:
             self.status = status
             self.save(update_fields=['status'])


### PR DESCRIPTION
Reintroduce abandoned disconnect_after_delivery parameter for Email.dispatch.
The disconnect_after_delivery parameter got deleted in https://github.com/ui/django-post_office/commit/03d1a3771eaca0c226ca5a7e299f8752f3707c43.