### PR TITLE
Improved document for an issue with celery integration shared task

### DIFF
--- a/README.md
+++ b/README.md
@@ -694,6 +694,16 @@ after they have been added to the mail queue. The delivery is still
 performed in a separate and asynchronous task, which prevents sending
 emails during the request/response-cycle.
 
+In order to setup django post office with celery worker you need to add this configurations to your project settings:
+```python
+# Add this to django project settings.py
+POST_OFFICE = {
+    ...
+    'CELERY_ENABLED': True,
+}
+```
+WARNING: If you don't add this section to your settings you might face some issues with celery finding django post office's shared task!
+
 If you [configured Celery](https://docs.celeryproject.org/en/latest/userguide/application.html)
 in your project and started the [Celery worker](https://docs.celeryproject.org/en/latest/userguide/workers.html),
 you should see something such as:


### PR DESCRIPTION
Hi Everyone,

I hope this PR finds you well!

So I've been using the django-post-office for a while now and I had an issue with celery not being able to find the package's shared celery task.

So let's review the cause root:
As stated in [tasks.py](https://github.com/ui/django-post_office/blob/master/post_office/tasks.py) file, the value of `get_celery_enabled()` must return `True` in order for post office to import celery shared_task function.
```python
try:
    if get_celery_enabled():
        from celery import shared_task
    else:
        raise NotImplementedError()
...
```
As I checked the `get_celery_enabled` [function](https://github.com/ui/django-post_office/blob/1ca14f66dfe097106058cca1c485a169a250c4f3/post_office/settings.py#L82), it is actually reading from `POST_OFFICE` setting configurations and check the value of `CELERY_ENABLED`.
```python
def get_celery_enabled():
    return get_config().get('CELERY_ENABLED', False)
```
Hence, we must add this section to our project settings:

```python
POST_OFFICE = {
    ...
    'CELERY_ENABLED': True,
}
```

Cheers,
Mohammad