### PR TITLE
Fix RemovedInDjango40Warning

### DIFF
--- a/post_office/signals.py
+++ b/post_office/signals.py
@@ -1,6 +1,6 @@
 from django.dispatch import Signal
 
-email_queued = Signal(providing_args=['emails'])
+email_queued = Signal()
 """
 This signal is triggered whenever Post Office pushes one or more emails into its queue.
 The Emails objects added to the queue are passed as list to the callback handler. 


### PR DESCRIPTION
RemovedInDjango40Warning: The providing_args argument is deprecated. As it is purely documentational, it has no replacement. If you rely on this argument as documentation, you can move the text to a code comment or docstring.