### PR TITLE
Add the ability to save context to the database even if rendering immediately

### DIFF
--- a/post_office/mail.py
+++ b/post_office/mail.py
@@ -29,7 +29,7 @@ logger = setup_loghandlers("INFO")
 def create(sender, recipients=None, cc=None, bcc=None, subject='', message='',
            html_message='', context=None, scheduled_time=None, expires_at=None, headers=None,
            template=None, priority=None, render_on_delivery=False, commit=True,
-           backend=''):
+           backend='', save_context=False):
     """
     Creates an email from supplied keyword arguments. If template is
     specified, email subject and content will be rendered during delivery.
@@ -73,6 +73,9 @@ def create(sender, recipients=None, cc=None, bcc=None, subject='', message='',
         subject = Template(subject).render(_context)
         message = Template(message).render(_context)
         html_message = Template(html_message).render(_context)
+        
+        if not save_context:
+            context = None
 
         email = Email(
             from_email=sender,
@@ -86,7 +89,8 @@ def create(sender, recipients=None, cc=None, bcc=None, subject='', message='',
             expires_at=expires_at,
             message_id=message_id,
             headers=headers, priority=priority, status=status,
-            backend_alias=backend
+            backend_alias=backend,
+            context=context
         )
 
     if commit:

--- a/post_office/mail.py
+++ b/post_office/mail.py
@@ -103,7 +103,7 @@ def send(recipients=None, sender=None, template=None, context=None, subject='',
          message='', html_message='', scheduled_time=None, expires_at=None, headers=None,
          priority=None, attachments=None, render_on_delivery=False,
          log_level=None, commit=True, cc=None, bcc=None, language='',
-         backend=''):
+         backend='', save_context=False):
     try:
         recipients = parse_emails(recipients)
     except ValidationError as e:
@@ -155,7 +155,7 @@ def send(recipients=None, sender=None, template=None, context=None, subject='',
 
     email = create(sender, recipients, cc, bcc, subject, message, html_message,
                    context, scheduled_time, expires_at, headers, template, priority,
-                   render_on_delivery, commit=commit, backend=backend)
+                   render_on_delivery, commit=commit, backend=backend, save_context=save_context)
 
     if attachments:
         attachments = create_attachments(attachments)


### PR DESCRIPTION
Added a save_context option on mail.send so that you can add the context to the database.  This is useful if you want to be able to retrieve mails related to a particular object id or subject later.