### PR TITLE
Fix RemovedInDjango41Warning

### DIFF
--- a/post_office/__init__.py
+++ b/post_office/__init__.py
@@ -1,3 +1,4 @@
+import django
 from ast import literal_eval
 from os.path import dirname, join
 
@@ -6,4 +7,5 @@ with open(join(dirname(__file__), 'version.txt'), 'r') as fh:
 
 from .backends import EmailBackend
 
-default_app_config = 'post_office.apps.PostOfficeConfig'
+if django.VERSION < (3, 2): # pragma: no cover
+    default_app_config = 'post_office.apps.PostOfficeConfig'


### PR DESCRIPTION
RemovedInDjango41Warning: 'post_office' defines default_app_config = 'post_office.apps.PostOfficeConfig'. Django now detects this configuration automatically. You can remove default_app_config.