### PR TITLE
Fix tests: pins dependency versions in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ setup(
     zip_safe=False,
     include_package_data=True,
     package_data={'': ['README.rst']},
-    install_requires=['django>=2.2', 'jsonfield>=3.0', 'bleach', 'pytz'],
+    install_requires=['django>=2.2', 'jsonfield>=3.0', 'bleach<=4.1.0', 'pytz'],
     classifiers=[
         'Development Status :: 5 - Production/Stable',
         'Environment :: Web Environment',


### PR DESCRIPTION
Dependency `bleach` was updated to v5.0.0 and django-post_office tests are failing with this version of bleach.

Pinning the version to `bleach<=4.1.0` makes tests run again for now.