### PR TITLE
Fix bug ignoring EmailMessage's `reply_to` property in resulting headers

### DIFF
--- a/post_office/backends.py
+++ b/post_office/backends.py
@@ -29,6 +29,9 @@ class EmailBackend(BaseEmailBackend):
             subject = email_message.subject
             from_email = email_message.from_email
             headers = email_message.extra_headers
+            if email_message.reply_to:
+                reply_to_header = ", ".join(str(v) for v in email_message.reply_to)
+                headers.setdefault("Reply-To", reply_to_header)
             message = email_message.message()
 
             # Look for first 'text/plain' and 'text/html' alternative in email


### PR DESCRIPTION
Adds tests and a fix that 'Reply-To' headers are correctly set, when `reply_to` property of the message object is set (using the initializer argument `reply_to`).

Also, when `reply_to` property is set and header "Reply-To" is also added explictly as a header, then the explicit header value is favored over the message property reply_to, adopting the behaviour of message() in django.core.mail.message.EmailMessage.