### PR TITLE
Fix: save template even if not rendered on delivery (fix #395)

### DIFF
--- a/post_office/mail.py
+++ b/post_office/mail.py
@@ -86,7 +86,8 @@ def create(sender, recipients=None, cc=None, bcc=None, subject='', message='',
             expires_at=expires_at,
             message_id=message_id,
             headers=headers, priority=priority, status=status,
-            backend_alias=backend
+            backend_alias=backend,
+            template=template,
         )
 
     if commit:


### PR DESCRIPTION
When creating an email in the `create` function (`mail.py`) without the `render_on_delivery` option, it should still save the template, as it was still used and can be usefull for admin purposes.

This should solve #395  

