### PR TITLE
fix HTML wouldn't be rendered in email body

### DIFF
--- a/post_office/models.py
+++ b/post_office/models.py
@@ -140,6 +140,7 @@ class Email(models.Model):
                     subject=subject, body=html_message, from_email=self.from_email,
                     to=self.to, bcc=self.bcc, cc=self.cc,
                     headers=headers, connection=connection)
+                msg.attach_alternative(html_message, "text/html")
                 msg.content_subtype = 'html'
             if hasattr(multipart_template, 'attach_related'):
                 multipart_template.attach_related(msg)


### PR DESCRIPTION
resolve issue [406](https://github.com/ui/django-post_office/issues/406).
added calling `attach_alternative()` method for including extra versions of the message body in the email