### PR TITLE
Fix: templates are not included in package (closes #404)

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -5,3 +5,4 @@ include post_office/version.txt
 recursive-include post_office *.py
 recursive-include post_office/locale *.po
 recursive-include post_office/locale *.mo
+recursive-include post_office/templates *.html


### PR DESCRIPTION
Includes the template HTML files in MANIFEST.in so that they get included into the pip package.
closes #404 