### PR TITLE
Remove redundant dependency on bleach

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,12 @@ setup(
     zip_safe=False,
     include_package_data=True,
     package_data={'': ['README.rst']},
-    install_requires=['django>=2.2', 'jsonfield>=3.0', 'bleach', 'bleach[css]', 'pytz'],
+    install_requires=[
+        'bleach[css]',
+        'django>=2.2',
+        'jsonfield>=3.0',
+        'pytz',
+    ],
     classifiers=[
         'Development Status :: 5 - Production/Stable',
         'Environment :: Web Environment',


### PR DESCRIPTION
This double dependency is causing a kind of flip-flopping behaviour with [pip-tools](https://github.com/jazzband/pip-tools). pip-compile on one machine picks up the `bleach[css]` dependency, and adds in `tinycss`. Then on another it sees only the `bleach` dependency, and removes `tinycss`.

Pip itself seems fine, and merges the two, but it's not standard.