### PR TITLE
Optimize AttachmentAdmin

### DIFF
--- a/post_office/admin.py
+++ b/post_office/admin.py
@@ -322,6 +322,7 @@ class AttachmentAdmin(admin.ModelAdmin):
     list_display = ['name', 'file']
     filter_horizontal = ['emails']
     search_fields = ["name"]
+    autocomplete_fields = ["emails"]
 
 
 admin.site.register(Email, EmailAdmin)


### PR DESCRIPTION
It fixes problem of long rendering time at attachment detail admin page when you have a lot entries in DB. It takes few minutes in our environment because of 170k options in select.

![image](https://github.com/ui/django-post_office/assets/2625825/76be5b67-dbdb-4026-8b07-129b52fc7a61)
