### PR TITLE
Successfully prepare email with context but without template

### DIFF
--- a/post_office/models.py
+++ b/post_office/models.py
@@ -104,7 +104,7 @@ class Email(models.Model):
         if get_override_recipients():
             self.to = get_override_recipients()
 
-        if self.context is not None:
+        if self.template is not None and self.context is not None:
             engine = get_template_engine()
             subject = engine.from_string(self.template.subject).render(self.context)
             plaintext_message = engine.from_string(self.template.content).render(self.context)

--- a/post_office/tests/test_models.py
+++ b/post_office/tests/test_models.py
@@ -65,6 +65,20 @@ class ModelTest(TestCase):
         self.assertEqual(message.body, 'Content test')
         self.assertEqual(message.alternatives[0][0], 'HTML test')
 
+    def test_email_message_prepare_without_template_and_with_context(self):
+        """
+        Ensure Email instance without template but with context is properly prepared.
+        """
+        context = {'name': 'test'}
+        email = Email.objects.create(to=['to@example.com'], template=None,
+                                     subject='Subject test', message='Content test',
+                                     html_message='HTML test',
+                                     from_email='from@e.com', context=context)
+        message = email.email_message()
+        self.assertEqual(message.subject, 'Subject test')
+        self.assertEqual(message.body, 'Content test')
+        self.assertEqual(message.alternatives[0][0], 'HTML test')
+
     def test_dispatch(self):
         """
         Ensure that email.dispatch() actually sends out the email


### PR DESCRIPTION
This change should fix the case when Email instance stores context, but not the template.

It's quite useful to store context for debug purposes even if you store already rendered message.

https://github.com/ui/django-post_office/issues/421#issuecomment-1282609243