### PR TITLE
Always send `email_queued` signal when queuing emails

### DIFF
--- a/post_office/mail.py
+++ b/post_office/mail.py
@@ -231,7 +231,8 @@ def send(
 
     if priority == PRIORITY.now:
         email.dispatch(log_level=log_level)
-    email_queued.send(sender=Email, emails=[email])
+    elif commit:
+        email_queued.send(sender=Email, emails=[email])
 
     return email
 

--- a/post_office/utils.py
+++ b/post_office/utils.py
@@ -6,6 +6,7 @@ from django.utils.encoding import force_str
 from post_office import cache
 from .models import Email, PRIORITY, STATUS, EmailTemplate, Attachment
 from .settings import get_default_priority
+from .signals import email_queued
 from .validators import validate_email_with_name
 
 
@@ -28,6 +29,8 @@ def send_mail(subject, message, from_email, recipient_list, html_message='',
     if priority == PRIORITY.now:
         for email in emails:
             email.dispatch()
+    else:
+        email_queued.send(sender=Email, emails=emails)
     return emails
 
 


### PR DESCRIPTION
Make sure to always send email_queued signal when creating emails with a priority other than "now", no matter by which means they are created.

Fixes #435 