### PR TITLE
Send many returns created emails

### DIFF
--- a/post_office/mail.py
+++ b/post_office/mail.py
@@ -237,6 +237,8 @@ def send_many(kwargs_list):
         Email.objects.bulk_create(emails)
         email_queued.send(sender=Email, emails=emails)
 
+    return emails
+
 
 def get_queued():
     """


### PR DESCRIPTION
Returning the created emails here is useful in case we need to use the objects after bulk sending