### PR TITLE
Add post office email object reference to EmailMessage

### DIFF
--- a/post_office/messages.py
+++ b/post_office/messages.py
@@ -1,6 +1,9 @@
+from typing import TYPE_CHECKING
+
 from django.core.mail import EmailMessage, EmailMultiAlternatives
 
-from .models import Email
+if TYPE_CHECKING:
+    from .models import Email
 
 
 class PostOfficeEmailMessage(EmailMessage):

--- a/post_office/messages.py
+++ b/post_office/messages.py
@@ -1,0 +1,15 @@
+from django.core.mail import EmailMessage, EmailMultiAlternatives
+
+from .models import Email
+
+
+class PostOfficeEmailMessage(EmailMessage):
+    def __init__(self, email: 'Email', *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+        self.post_office_email = email
+
+
+class PostOfficeEmailMultiAlternatives(EmailMultiAlternatives):
+    def __init__(self, email: 'Email', *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+        self.post_office_email = email

--- a/post_office/models.py
+++ b/post_office/models.py
@@ -160,6 +160,7 @@ class Email(models.Model):
 
         else:
             msg = PostOfficeEmailMessage(
+                email=self,
                 subject=subject,
                 body=plaintext_message,
                 from_email=self.from_email,

--- a/post_office/models.py
+++ b/post_office/models.py
@@ -131,6 +131,7 @@ class Email(models.Model):
         if html_message:
             if plaintext_message:
                 msg = PostOfficeEmailMultiAlternatives(
+                    email=self,
                     subject=subject,
                     body=plaintext_message,
                     from_email=self.from_email,
@@ -139,11 +140,11 @@ class Email(models.Model):
                     cc=self.cc,
                     headers=headers,
                     connection=connection,
-                    email=self,
                 )
                 msg.attach_alternative(html_message, 'text/html')
             else:
                 msg = PostOfficeEmailMultiAlternatives(
+                    email=self,
                     subject=subject,
                     body=html_message,
                     from_email=self.from_email,
@@ -152,7 +153,6 @@ class Email(models.Model):
                     cc=self.cc,
                     headers=headers,
                     connection=connection,
-                    email=self,
                 )
                 msg.content_subtype = 'html'
             if hasattr(multipart_template, 'attach_related'):

--- a/post_office/tests/test_models.py
+++ b/post_office/tests/test_models.py
@@ -32,7 +32,7 @@ class ModelTest(TestCase):
             html_message='<p>HTML</p>',
         )
         message = email.email_message()
-        self.assertEqual(type(message), EmailMultiAlternatives)
+        self.assertTrue(isinstance(message, EmailMultiAlternatives))
         self.assertEqual(message.from_email, 'from@example.com')
         self.assertEqual(message.to, ['to@example.com'])
         self.assertEqual(message.subject, 'Subject')
@@ -44,7 +44,7 @@ class ModelTest(TestCase):
             to=['to@example.com'], from_email='from@example.com', subject='Subject', message='Message'
         )
         message = email.email_message()
-        self.assertEqual(type(message), EmailMessage)
+        self.assertTrue(isinstance(message, EmailMessage))
         self.assertEqual(message.from_email, 'from@example.com')
         self.assertEqual(message.to, ['to@example.com'])
         self.assertEqual(message.subject, 'Subject')


### PR DESCRIPTION
I need to implement  a custom `BaseEmailBackend` and override its `send_messages` function which takes a list of django `EmailMessage`. After sending the message, I need to save the external email ID to the db. By providing a reference to the email object, we wont  need to query for the email again and we can update easier. 