### PR TITLE
Better string representations for Email model

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,12 +24,14 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
-        django-version: ["4.2", "5.0", "5.1"]
+        django-version: ["4.2", "5.0", "5.1", "5.2"]
         exclude:
           - python-version: "3.9"
             django-version: "5.0"
           - python-version: "3.9"
             django-version: "5.1"
+          - python-version: "3.9"
+            django-version: "5.2"
 
     steps:
       - uses: actions/checkout@v4

--- a/post_office/models.py
+++ b/post_office/models.py
@@ -85,8 +85,11 @@ class Email(models.Model):
         super().__init__(*args, **kwargs)
         self._cached_email_message = None
 
+    def __repr__(self):
+        return '<%s: %s>' % (self.__class__.__name__, self.to)
+
     def __str__(self):
-        return '%s' % self.to
+        return f"{', '.join(self.to)}"
 
     def email_message(self):
         """

--- a/post_office/tests/test_models.py
+++ b/post_office/tests/test_models.py
@@ -295,7 +295,8 @@ class ModelTest(TestCase):
         self.assertEqual(email.priority, PRIORITY.medium)
 
     def test_string_priority_exception(self):
-        invalid_priority_send = lambda: send(['to1@example.com'], 'from@a.com', priority='hgh')
+        def invalid_priority_send():
+            send(['to1@example.com'], 'from@a.com', priority='hgh')
 
         with self.assertRaises(ValueError) as context:
             invalid_priority_send()
@@ -353,8 +354,10 @@ class ModelTest(TestCase):
         self.assertEqual(repr(Email(to=['test@example.com'])), "<Email: ['test@example.com']>")
 
     def test_models_str(self):
-        self.assertEqual(str(Email(to=['test@example.com'])), "test@example.com")
-        self.assertEqual(str(Email(to=['test@example.com', 'test2@example.com'])), "test@example.com, test2@example.com")
+        self.assertEqual(str(Email(to=['test@example.com'])), 'test@example.com')
+        self.assertEqual(
+            str(Email(to=['test@example.com', 'test2@example.com'])), 'test@example.com, test2@example.com'
+        )
 
     def test_natural_key(self):
         template = EmailTemplate.objects.create(name='name')

--- a/post_office/tests/test_models.py
+++ b/post_office/tests/test_models.py
@@ -352,6 +352,10 @@ class ModelTest(TestCase):
         self.assertEqual(repr(EmailTemplate(name='test', language='en')), '<EmailTemplate: test en>')
         self.assertEqual(repr(Email(to=['test@example.com'])), "<Email: ['test@example.com']>")
 
+    def test_models_str(self):
+        self.assertEqual(str(Email(to=['test@example.com'])), "test@example.com")
+        self.assertEqual(str(Email(to=['test@example.com', 'test2@example.com'])), "test@example.com, test2@example.com")
+
     def test_natural_key(self):
         template = EmailTemplate.objects.create(name='name')
         self.assertEqual(template, EmailTemplate.objects.get_by_natural_key(*template.natural_key()))


### PR DESCRIPTION
I tweaked the way the email model is stringified so it displays better in the admin. But I kept the internal `__repr__` method the way it was previously.

Note the breadcrumbs and the subtitle.

Previous admin:

![previous django admin that displays email "to" addresses in a Python-esque syntax list](https://github.com/user-attachments/assets/1107b4fa-b098-4dca-a895-46eb7f4f7ef0)

New admin:

![new django admin that displays email "to" addresses in a comma-separated format](https://github.com/user-attachments/assets/6c3720cb-86a7-49ba-8569-fc6365a16e21)

As a bonus, I also added Django 5.2 to the GitHub Actions test matrix.