### PR TITLE
Fixup packaging

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,7 +1,6 @@
 include LICENSE.txt
 include README.rst
 include AUTHORS.rst
-include post_office/version.txt
 recursive-include post_office *.py
 recursive-include post_office/locale *.po
 recursive-include post_office/locale *.mo

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -5,3 +5,5 @@ recursive-include post_office *.py
 recursive-include post_office/locale *.po
 recursive-include post_office/locale *.mo
 recursive-include post_office/templates *.html
+recursive-exclude post_office/tests *.py
+recursive-exclude post_office/ test_*.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "django-post_office"
+license = "MIT"
 requires-python = ">=3.9"
 authors = [{name = "Selwin Ong", email = "selwin.ong@gmail.com"}]
 description = "A Django app to monitor and send mail asynchronously, complete with template support."
@@ -17,7 +18,6 @@ classifiers = [
     "Framework :: Django :: 5.1",
     "Framework :: Django :: 5.2",
     "Intended Audience :: Developers",
-    "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
@@ -53,9 +53,7 @@ testing = [
 ]
 
 [tool.setuptools]
-packages = ["post_office"]
 zip-safe = false
-include-package-data = true
 
 [tool.setuptools.dynamic]
 version = {attr = "post_office.version.VERSION"}


### PR DESCRIPTION
I didn't realize that `post_office/version.txt` was still listed in `MANIFEST.in` in PR #482.

This causes issues when attempting to install this package from a Git repository.

I also removed some of the entries in `pyproject.toml` that were causing warnings when building with `python3 -m build`, and tweaked `MANIFEST.in` to exclude test files, since we don't need to ship those.