### PR TITLE
Restrict add/change/delete permissions in LogAdmin

### DIFF
--- a/post_office/admin.py
+++ b/post_office/admin.py
@@ -227,6 +227,9 @@ class LogAdmin(admin.ModelAdmin):
     def has_change_permission(self, request, obj=None):
         return False
 
+    def has_delete_permission(self, request, obj=None):
+        return False
+
 class SubjectField(TextInput):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)


### PR DESCRIPTION
I don't think it makes sense to be able to add or edit logs in the admin interface. This is already disabled in `LogInline`, but it seems it was forgotten here.