### PR TITLE
Add fallback language support in get_template with try/catch error ha…

### DIFF
--- a/post_office/mail.py
+++ b/post_office/mail.py
@@ -201,9 +201,16 @@ def send(
             template = template
             # If language is specified, ensure template uses the right language
             if language and template.language != language:
-                template = template.translated_templates.get(language=language)
+                                    try:
+                                                                template = template.translated_templates.get(language=language)
+                                    except EmailTemplate.DoesNotExist:
+                                                                pass  # Keep original template if translation not found
         else:
-            template = get_email_template(template, language)
+            try:
+                                template = get_email_template(template, language)
+            except EmailTemplate.DoesNotExist:
+                                # Fallback to template without language if translation not found
+                                template = get_email_template(template)
 
     if backend and backend not in get_available_backends().keys():
         raise ValueError('%s is not a valid backend alias' % backend)


### PR DESCRIPTION
…ndling

Fixes #515

This PR wraps template retrieval logic in try/catch blocks so that:
- If a translated template lookup fails via translated_templates.get(), the original template is kept
- If get_email_template() fails for a specific language, it falls back to getting the template without language

This prevents the entire email sending operation from failing when a translation is unavailable.