### PR TITLE
Separate backend each threads on send_queued_mail

### DIFF
--- a/post_office/mail.py
+++ b/post_office/mail.py
@@ -41,11 +41,12 @@ logger = setup_loghandlers('INFO')
 
 def _send_email(email: Email, log_level: int) -> tuple[bool, Optional[Exception]]:
     try:
-        email.dispatch(log_level=log_level, commit=False, disconnect_after_delivery=False)
-        logger.debug('Successfully sent email #%d' % email.id)
+        connection = connections[email.backend_alias or 'default']
+        email.dispatch(log_level=log_level, commit=False, disconnect_after_delivery=False, connection=connection)
+        logger.debug(f'Successfully sent email #{email.id}')
         return True, None
     except Exception as e:
-        logger.exception('Failed to send email #%d' % email.id)
+        logger.exception(f'Failed to send email #{email.id}')
         return False, e
 
 
@@ -162,17 +163,17 @@ def send(
     try:
         recipients = parse_emails(recipients)
     except ValidationError as e:
-        raise ValidationError('recipients: %s' % e.message)
+        raise ValidationError(f'recipients: {e.message}')
 
     try:
         cc = parse_emails(cc)
     except ValidationError as e:
-        raise ValidationError('c: %s' % e.message)
+        raise ValidationError(f'c: {e.message}')
 
     try:
         bcc = parse_emails(bcc)
     except ValidationError as e:
-        raise ValidationError('bcc: %s' % e.message)
+        raise ValidationError(f'bcc: {e.message}')
 
     if sender is None:
         sender = settings.DEFAULT_FROM_EMAIL
@@ -206,7 +207,7 @@ def send(
             template = get_email_template(template, language)
 
     if backend and backend not in get_available_backends().keys():
-        raise ValueError('%s is not a valid backend alias' % backend)
+        raise ValueError(f'{backend} is not a valid backend alias')
 
     email = create(
         sender,
@@ -296,7 +297,7 @@ def send_queued(processes: int = 1, log_level: Optional[int] = None) -> tuple[in
     total_sent, total_failed, total_requeued = 0, 0, 0
     total_email = len(queued_emails)
 
-    logger.info('Started sending %s emails with %s processes.' % (total_email, processes))
+    logger.info(f'Started sending {total_email} emails with {processes} processes.')
 
     if log_level is None:
         log_level = get_log_level()
@@ -363,7 +364,7 @@ def _send_bulk(
     failed_emails = []  # This is a list of two tuples (email, exception)
     email_count = len(emails)
 
-    logger.info('Process started, sending %s emails' % email_count)
+    logger.info(f'Process started, sending {email_count} emails')
 
     emails_to_send = []
 
@@ -376,7 +377,7 @@ def _send_bulk(
             email.prepare_email_message()
             emails_to_send.append(email)
         except Exception as e:
-            logger.exception('Failed to prepare email #%d' % email.id)
+            logger.exception(f'Failed to prepare email #{email.id}')
             failed_emails.append((email, e))
 
     number_of_threads = min(get_threads_per_process(), email_count)

--- a/post_office/models.py
+++ b/post_office/models.py
@@ -104,7 +104,7 @@ class Email(models.Model):
         self._cached_email_message = None
 
     def __repr__(self):
-        return '<%s: %s>' % (self.__class__.__name__, self.to)
+        return f'<{self.__class__.__name__}: {self.to}>'
 
     def __str__(self):
         return f'{", ".join(self.to)}'
@@ -139,6 +139,7 @@ class Email(models.Model):
             multipart_template = None
             html_message = self.html_message
 
+        connection = connections[self.backend_alias or 'default']
         if isinstance(self.headers, dict) or self.expires_at or self.message_id:
             headers = dict(self.headers or {})
             if self.expires_at:
@@ -158,6 +159,7 @@ class Email(models.Model):
                     bcc=self.bcc,
                     cc=self.cc,
                     headers=headers,
+                    connection=connection,
                 )
                 msg.attach_alternative(html_message, 'text/html')
             else:
@@ -169,6 +171,7 @@ class Email(models.Model):
                     bcc=self.bcc,
                     cc=self.cc,
                     headers=headers,
+                    connection=connection,
                 )
                 msg.content_subtype = 'html'
             if hasattr(multipart_template, 'attach_related'):
@@ -183,6 +186,7 @@ class Email(models.Model):
                 bcc=self.bcc,
                 cc=self.cc,
                 headers=headers,
+                connection=connection,
             )
 
         for attachment in self.attachments.all():
@@ -325,7 +329,7 @@ class EmailTemplate(models.Model):
         ordering = ['name']
 
     def __str__(self):
-        return '%s %s' % (self.name, self.language)
+        return f'{self.name} {self.language}'
 
     def natural_key(self):
         return (self.name, self.language, self.default_template)

--- a/post_office/models.py
+++ b/post_office/models.py
@@ -217,7 +217,7 @@ class Email(models.Model):
         """
         try:
             msg = self.email_message()
-            if connection:
+            if connection is not None:
                 msg.connection = connection
             msg.send()
             status = STATUS.sent

--- a/post_office/models.py
+++ b/post_office/models.py
@@ -112,8 +112,14 @@ class Email(models.Model):
     def email_message(self):
         """
         Returns Django EmailMessage object for sending.
+
+        The connection is always re-fetched from the thread-local registry so
+        that worker threads each use their own backend/session rather than
+        sharing the one that was embedded when prepare_email_message() ran in
+        the main thread.
         """
         if self._cached_email_message:
+            self._cached_email_message.connection = connections[self.backend_alias or 'default']
             return self._cached_email_message
 
         return self.prepare_email_message()

--- a/post_office/models.py
+++ b/post_office/models.py
@@ -209,12 +209,16 @@ class Email(models.Model):
     def dispatch(self, log_level=None, disconnect_after_delivery=True, commit=True, connection=None):
         """
         Sends email and log the result.
+
+        If ``connection`` is provided, it overrides the connection embedded in
+        the email message by ``prepare_email_message()``. This allows callers
+        (e.g. worker threads) to supply a thread-local connection rather than
+        reusing one that was opened in a different thread.
         """
         try:
             msg = self.email_message()
-            if connection is None:
-                connection = connections[self.backend_alias or 'default']
-            msg.connection = connection
+            if connection:
+                msg.connection = connection
             msg.send()
             status = STATUS.sent
             message = ''

--- a/post_office/models.py
+++ b/post_office/models.py
@@ -112,14 +112,8 @@ class Email(models.Model):
     def email_message(self):
         """
         Returns Django EmailMessage object for sending.
-
-        The connection is always re-fetched from the thread-local registry so
-        that worker threads each use their own backend/session rather than
-        sharing the one that was embedded when prepare_email_message() ran in
-        the main thread.
         """
         if self._cached_email_message:
-            self._cached_email_message.connection = connections[self.backend_alias or 'default']
             return self._cached_email_message
 
         return self.prepare_email_message()
@@ -145,7 +139,6 @@ class Email(models.Model):
             multipart_template = None
             html_message = self.html_message
 
-        connection = connections[self.backend_alias or 'default']
         if isinstance(self.headers, dict) or self.expires_at or self.message_id:
             headers = dict(self.headers or {})
             if self.expires_at:
@@ -165,7 +158,6 @@ class Email(models.Model):
                     bcc=self.bcc,
                     cc=self.cc,
                     headers=headers,
-                    connection=connection,
                 )
                 msg.attach_alternative(html_message, 'text/html')
             else:
@@ -177,7 +169,6 @@ class Email(models.Model):
                     bcc=self.bcc,
                     cc=self.cc,
                     headers=headers,
-                    connection=connection,
                 )
                 msg.content_subtype = 'html'
             if hasattr(multipart_template, 'attach_related'):
@@ -192,7 +183,6 @@ class Email(models.Model):
                 bcc=self.bcc,
                 cc=self.cc,
                 headers=headers,
-                connection=connection,
             )
 
         for attachment in self.attachments.all():
@@ -212,12 +202,16 @@ class Email(models.Model):
         self._cached_email_message = msg
         return msg
 
-    def dispatch(self, log_level=None, disconnect_after_delivery=True, commit=True):
+    def dispatch(self, log_level=None, disconnect_after_delivery=True, commit=True, connection=None):
         """
         Sends email and log the result.
         """
         try:
-            self.email_message().send()
+            msg = self.email_message()
+            if connection is None:
+                connection = connections[self.backend_alias or 'default']
+            msg.connection = connection
+            msg.send()
             status = STATUS.sent
             message = ''
             exception_type = ''

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -9,6 +9,7 @@ from django.test import TestCase, TransactionTestCase
 from django.test.utils import override_settings
 from django.utils.timezone import now
 
+from post_office.connections import ConnectionHandler
 from post_office.models import STATUS, Attachment, Email
 
 
@@ -146,30 +147,29 @@ class CommandTest(TestCase):
     )
     def test_send_queued_mail_threads_use_independent_connections(self):
         """
-        Worker threads must each obtain their own thread-local connection from the
-        registry rather than sharing the connection embedded during prepare_email_message().
+        Worker threads must each obtain their own thread-local connection from
+        ConnectionHandler so that no single connection is shared across threads.
         """
         for _ in range(3):
             Email.objects.create(from_email='from@example.com', to=['to@example.com'], status=STATUS.queued)
 
-        # Map thread_id -> set of connection object ids seen via email_message()
+        # Map thread_id -> set of connection object ids fetched from ConnectionHandler
         conn_usage: dict[int, set[int]] = {}
         usage_lock = threading.Lock()
-        original_email_message = Email.email_message
+        original_getitem = ConnectionHandler.__getitem__
 
-        def tracking_email_message(self):
-            msg = original_email_message(self)
+        def tracking_getitem(self, alias):
+            conn = original_getitem(self, alias)
             with usage_lock:
-                conn_usage.setdefault(threading.current_thread().ident, set()).add(id(msg.connection))
-            return msg
+                conn_usage.setdefault(threading.current_thread().ident, set()).add(id(conn))
+            return conn
 
-        with patch.object(Email, 'email_message', tracking_email_message):
+        with patch.object(ConnectionHandler, '__getitem__', tracking_getitem):
             call_command('send_queued_mail', processes=1)
 
         self.assertEqual(Email.objects.filter(status=STATUS.sent).count(), 3)
 
-        # email_message() is only called inside worker threads (dispatch runs in the pool)
-        self.assertGreater(len(conn_usage), 0, 'No email_message() calls were tracked')
+        self.assertGreater(len(conn_usage), 0, 'No connections were fetched from ConnectionHandler')
 
         # Build a map from connection id -> set of threads that used it
         conn_to_threads: dict[int, set[int]] = {}

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -1,5 +1,7 @@
 import datetime
 import os
+import threading
+from unittest.mock import patch
 
 from django.core.files.base import ContentFile
 from django.core.management import call_command
@@ -132,3 +134,51 @@ class CommandTest(TestCase):
         )
         call_command('send_queued_mail', log_level=2)
         self.assertEqual(email.logs.count(), 1)
+
+    @override_settings(
+        POST_OFFICE={
+            'BACKENDS': {
+                'default': 'django.core.mail.backends.dummy.EmailBackend',
+            },
+            'BATCH_SIZE': 10,
+            'THREADS_PER_PROCESS': 2,
+        }
+    )
+    def test_send_queued_mail_threads_use_independent_connections(self):
+        """
+        Worker threads must each obtain their own thread-local connection from the
+        registry rather than sharing the connection embedded during prepare_email_message().
+        """
+        for _ in range(3):
+            Email.objects.create(from_email='from@example.com', to=['to@example.com'], status=STATUS.queued)
+
+        # Map thread_id -> set of connection object ids seen via email_message()
+        conn_usage: dict[int, set[int]] = {}
+        usage_lock = threading.Lock()
+        original_email_message = Email.email_message
+
+        def tracking_email_message(self):
+            msg = original_email_message(self)
+            with usage_lock:
+                conn_usage.setdefault(threading.current_thread().ident, set()).add(id(msg.connection))
+            return msg
+
+        with patch.object(Email, 'email_message', tracking_email_message):
+            call_command('send_queued_mail', processes=1)
+
+        self.assertEqual(Email.objects.filter(status=STATUS.sent).count(), 3)
+
+        # email_message() is only called inside worker threads (dispatch runs in the pool)
+        self.assertGreater(len(conn_usage), 0, 'No email_message() calls were tracked')
+
+        # Build a map from connection id -> set of threads that used it
+        conn_to_threads: dict[int, set[int]] = {}
+        for tid, conn_ids in conn_usage.items():
+            for cid in conn_ids:
+                conn_to_threads.setdefault(cid, set()).add(tid)
+
+        shared = {cid: tids for cid, tids in conn_to_threads.items() if len(tids) > 1}
+        self.assertFalse(
+            shared,
+            f'Backend connections were shared across threads - thread safety violated: {shared}',
+        )

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -1,15 +1,12 @@
 import datetime
 import os
-import threading
-from unittest.mock import patch
 
 from django.core.files.base import ContentFile
 from django.core.management import call_command
-from django.test import TestCase, TransactionTestCase
+from django.test import TestCase
 from django.test.utils import override_settings
 from django.utils.timezone import now
 
-from post_office.connections import ConnectionHandler
 from post_office.models import STATUS, Attachment, Email
 
 
@@ -135,50 +132,3 @@ class CommandTest(TestCase):
         )
         call_command('send_queued_mail', log_level=2)
         self.assertEqual(email.logs.count(), 1)
-
-    @override_settings(
-        POST_OFFICE={
-            'BACKENDS': {
-                'default': 'django.core.mail.backends.dummy.EmailBackend',
-            },
-            'BATCH_SIZE': 10,
-            'THREADS_PER_PROCESS': 2,
-        }
-    )
-    def test_send_queued_mail_threads_use_independent_connections(self):
-        """
-        Worker threads must each obtain their own thread-local connection from
-        ConnectionHandler so that no single connection is shared across threads.
-        """
-        for _ in range(3):
-            Email.objects.create(from_email='from@example.com', to=['to@example.com'], status=STATUS.queued)
-
-        # Map thread_id -> set of connection object ids fetched from ConnectionHandler
-        conn_usage: dict[int, set[int]] = {}
-        usage_lock = threading.Lock()
-        original_getitem = ConnectionHandler.__getitem__
-
-        def tracking_getitem(self, alias):
-            conn = original_getitem(self, alias)
-            with usage_lock:
-                conn_usage.setdefault(threading.current_thread().ident, set()).add(id(conn))
-            return conn
-
-        with patch.object(ConnectionHandler, '__getitem__', tracking_getitem):
-            call_command('send_queued_mail', processes=1)
-
-        self.assertEqual(Email.objects.filter(status=STATUS.sent).count(), 3)
-
-        self.assertGreater(len(conn_usage), 0, 'No connections were fetched from ConnectionHandler')
-
-        # Build a map from connection id -> set of threads that used it
-        conn_to_threads: dict[int, set[int]] = {}
-        for tid, conn_ids in conn_usage.items():
-            for cid in conn_ids:
-                conn_to_threads.setdefault(cid, set()).add(tid)
-
-        shared = {cid: tids for cid, tids in conn_to_threads.items() if len(tids) > 1}
-        self.assertFalse(
-            shared,
-            f'Backend connections were shared across threads - thread safety violated: {shared}',
-        )

--- a/tests/test_mail.py
+++ b/tests/test_mail.py
@@ -131,31 +131,37 @@ class MailTest(TransactionTestCase):
         self.assertEqual(len(mail.outbox), 1)
         self.assertEqual(mail.outbox[0].subject, 'send bulk')
 
-    @override_settings(EMAIL_BACKEND='tests.test_mail.ConnectionTestingBackend')
+    @override_settings(
+        EMAIL_BACKEND='tests.test_mail.ConnectionTestingBackend',
+        POST_OFFICE={
+            'BACKENDS': {
+                'connection_tester': 'tests.test_mail.ConnectionTestingBackend',
+            },
+            'THREADS_PER_PROCESS': 1,
+        },
+    )
     def test_send_bulk_reuses_open_connection(self):
         """
-        Ensure _send_bulk() only opens connection once to send multiple emails.
+        Ensure _send_bulk() opens one connection per thread, not one per email.
+        With THREADS_PER_PROCESS=1: main thread opens one during prepare, worker
+        thread opens one during send — total 2 opens for any number of emails.
         """
         global connection_counter
         self.assertEqual(connection_counter, 0)
-        email = Email.objects.create(
-            to=['to@example.com'],
-            from_email='bob@example.com',
-            subject='',
-            message='',
-            status=STATUS.queued,
-            backend_alias='connection_tester',
+        email_1, email_2, email_3 = Email.objects.bulk_create(
+            [
+                Email(
+                    to=['to@example.com'],
+                    from_email='bob@example.com',
+                    subject='',
+                    message='',
+                    status=STATUS.queued,
+                    backend_alias='connection_tester',
+                ) for _ in range(3)
+            ]
         )
-        email_2 = Email.objects.create(
-            to=['to@example.com'],
-            from_email='bob@example.com',
-            subject='',
-            message='',
-            status=STATUS.queued,
-            backend_alias='connection_tester',
-        )
-        _send_bulk([email, email_2])
-        self.assertEqual(connection_counter, 1)
+        _send_bulk([email_1, email_2, email_3])
+        self.assertEqual(connection_counter, 2)
 
     def test_get_queued(self):
         """
@@ -381,9 +387,9 @@ class MailTest(TransactionTestCase):
         email = create(sender='from@example.com', recipients=['to@example.com'], template=template, context=context)
         today = timezone.datetime.today()
         current_year = today.year
-        self.assertEqual(email.subject, 'Subject %d' % current_year)
-        self.assertEqual(email.message, 'Content %d' % current_year)
-        self.assertEqual(email.html_message, 'HTML %d' % current_year)
+        self.assertEqual(email.subject, f'Subject {current_year}')
+        self.assertEqual(email.message, f'Content {current_year}')
+        self.assertEqual(email.html_message, f'HTML {current_year}')
         self.assertEqual(email.context, None)
         self.assertIsNotNone(email.template)
 

--- a/tests/test_mail.py
+++ b/tests/test_mail.py
@@ -157,7 +157,8 @@ class MailTest(TransactionTestCase):
                     message='',
                     status=STATUS.queued,
                     backend_alias='connection_tester',
-                ) for _ in range(3)
+                )
+                for _ in range(3)
             ]
         )
         _send_bulk([email_1, email_2, email_3])

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,7 +1,7 @@
 import json
 import os
 from datetime import datetime, timedelta
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 from django.conf import settings as django_settings, settings
 from django.core import mail
@@ -133,7 +133,7 @@ class ModelTest(TestCase):
 
         email.dispatch(connection=mocked_connection)
         # message object's connection should be overridden by the provided one
-        self.assertEqual(email.email_message().connection, mocked_connection) 
+        self.assertEqual(email.email_message().connection, mocked_connection)
         mocked_connection.send_messages.assert_called_once()
 
     def test_status_and_log(self):

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,7 +1,7 @@
 import json
 import os
 from datetime import datetime, timedelta
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 from django.conf import settings as django_settings, settings
 from django.core import mail
@@ -11,6 +11,7 @@ from django.core.mail import EmailMessage, EmailMultiAlternatives
 from django.forms.models import modelform_factory
 from django.test import TestCase
 from django.utils import timezone
+from django.core.mail.backends.locmem import EmailBackend as LocMemEmailBackend
 
 from post_office.models import Email, Log, PRIORITY, STATUS, EmailTemplate, Attachment
 from post_office.mail import send
@@ -113,8 +114,8 @@ class ModelTest(TestCase):
 
     def test_dispatch_uses_provided_connection(self):
         """
-        Ensure dispatch() uses the explicitly passed connection to send the
-        message instead of fetching one from the registry.
+        Ensure dispatch() overrides msg.connection with the explicitly passed
+        connection, even when prepare_email_message() already embedded one.
         """
         email = Email.objects.create(
             to=['to@example.com'],
@@ -123,10 +124,17 @@ class ModelTest(TestCase):
             message='Message',
             backend_alias='locmem',
         )
-        mock_conn = MagicMock()
-        mock_conn.send_messages.return_value = 1
-        email.dispatch(connection=mock_conn, disconnect_after_delivery=False)
-        mock_conn.send_messages.assert_called_once()
+
+        mocked_connection = MagicMock()
+        mocked_connection.send_messages.return_value = 1
+
+        # sanity check, original connection embedded in email_message() should be a LocMemEmailBackend instance
+        self.assertTrue(isinstance(email.email_message().connection, LocMemEmailBackend))
+
+        email.dispatch(connection=mocked_connection)
+        # message object's connection should be overridden by the provided one
+        self.assertEqual(email.email_message().connection, mocked_connection) 
+        mocked_connection.send_messages.assert_called_once()
 
     def test_status_and_log(self):
         """

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,7 +1,7 @@
 import json
 import os
-
 from datetime import datetime, timedelta
+from unittest.mock import MagicMock
 
 from django.conf import settings as django_settings, settings
 from django.core import mail
@@ -110,6 +110,23 @@ class ModelTest(TestCase):
         email.dispatch()
         self.assertEqual(mail.outbox[0].to, ['override@gmail.com'])
         settings.POST_OFFICE = previous_settings
+
+    def test_dispatch_uses_provided_connection(self):
+        """
+        Ensure dispatch() uses the explicitly passed connection to send the
+        message instead of fetching one from the registry.
+        """
+        email = Email.objects.create(
+            to=['to@example.com'],
+            from_email='from@example.com',
+            subject='Test provided connection',
+            message='Message',
+            backend_alias='locmem',
+        )
+        mock_conn = MagicMock()
+        mock_conn.send_messages.return_value = 1
+        email.dispatch(connection=mock_conn, disconnect_after_delivery=False)
+        mock_conn.send_messages.assert_called_once()
 
     def test_status_and_log(self):
         """


### PR DESCRIPTION
## LLM Output Claude Sonnet 4.6

**Root Cause:** In `_send_bulk`, `prepare_email_message()` is called in the **main thread** before spawning worker threads. This embeds the main thread's `AnymailRequestsBackend` connection (and its `requests.Session`) into every email's `_cached_email_message`. When the `ThreadPool` workers dispatch those emails, all threads concurrently call `session.request()` on the **same shared `requests.Session`**, which is [explicitly not thread-safe](https://requests.readthedocs.io/en/latest/user/advanced/#session-objects). This corrupts socket state, causing `[Errno 11] Resource temporarily unavailable` at the OS level.

The fix: in `_send_email`, replace the pre-cached connection with a thread-local one from `connections[]` before dispatching. Since `ConnectionHandler` uses `threading.local`, each worker thread will get its own `AnymailRequestsBackend` with its own `requests.Session`. 


## Deeper Analysis
---

## 1. Why `requests.Session` is not thread-safe

A `Session` object holds mutable shared state:

```
session.cookies      ← mutable CookieJar
session.headers      ← mutable dict
session.adapters     ← HTTPAdapter with its PoolManager
session.env_proxies  ← mutated on each request()
```

The critical one is `session.request()` itself — it performs a **non-atomic read-modify-write** sequence:

```python
# Inside requests/sessions.py (simplified)
def request(self, method, url, ...):
    req = Request(...)
    prep = self.prepare_request(req)   # reads self.headers, self.cookies
    settings = self.merge_environment_settings(...)  # reads+writes self.env_proxies
    return self.send(prep, **settings)
```

When Thread A and Thread B both call `session.request()` at the same time, they both enter `prepare_request()` and `merge_environment_settings()` concurrently — reading and writing the same dict/cookie objects without locks. This is a classic TOCTOU (Time-of-Check-Time-of-Use) race.

---

## 2. Why does sharing corrupt socket state?

Go one level deeper: `HTTPAdapter` owns a `urllib3.PoolManager`, which maps hostnames → `HTTPConnectionPool`. Each pool has a `queue.LifoQueue` of `HTTPConnection` objects.

When 5 threads share the **same** adapter/pool and all call `adapter.send()` simultaneously:

```
Thread 1 ──→ pool.urlopen() → get conn from queue → send bytes → read response
Thread 2 ──→ pool.urlopen() → get conn from queue → ← queue is empty, create new conn
Thread 3 ──→ pool.urlopen() → get conn from queue → ← queue is empty, create new conn
Thread 4 ──→ pool.urlopen() → get conn from queue → ← queue is empty, create new conn
Thread 5 ──→ pool.urlopen() → get conn from queue → ← queue is empty, create new conn
```

All 5 threads simultaneously call `HTTPConnection._new_conn()` → `socket.create_connection()` → internally calls `socket.getaddrinfo()` for DNS.

At the OS level, DNS resolution requires creating its **own** temporary UDP socket to query the resolver. Five threads doing this at exactly the same instant means the OS must allocate 5 resolver sockets simultaneously, on top of the 5 TCP sockets being opened. When system resources are tight (file descriptor pressure, socket buffer limits, or the resolver queue is full), the kernel returns **EAGAIN** on one of those socket allocations.

---

## 3. Why specifically Errno 11 (`EAGAIN` / `Resource temporarily unavailable`)

`EAGAIN` (errno 11 on Linux) means: **"I can't do this right now — try again later."** It's the kernel's way of saying a resource is momentarily exhausted without hard-failing.

The exact call that fails, from the traceback:

```python
# urllib3/util/connection.py
for res in socket.getaddrinfo(host, port, family, socket.SOCK_STREAM):
```

`getaddrinfo` creates a non-blocking DNS socket internally. Under the hood, libc's resolver does:

```c
// Creates a UDP socket to talk to /etc/resolv.conf nameserver
fd = socket(AF_INET, SOCK_DGRAM | SOCK_NONBLOCK, ...)
// If the system socket table is temporarily saturated:
// → returns -1, errno = EAGAIN
```

So the chain is:

```
5 threads × (1 TCP socket + 1 DNS socket) = 10 simultaneous socket() syscalls
         ↓
system socket buffer / fd slots temporarily saturated
         ↓
socket() syscall returns EAGAIN
         ↓
Python raises BlockingIOError: [Errno 11]
         ↓
urllib3 wraps it as NewConnectionError
         ↓
requests wraps it as ConnectionError
         ↓
anymail wraps it as AnymailRequestsAPIError
```

---

## Why per-thread sessions fix it

With the fix, each worker thread calls `connections[alias]` which hits `threading.local` storage. The first access on a given thread creates a **brand new** `AnymailRequestsBackend` → new `requests.Session` → new `HTTPAdapter` → new `PoolManager`. Now:

```
Thread 1 → its own Session → its own socket lifecycle
Thread 2 → its own Session → its own socket lifecycle
Thread 3 → its own Session → its own socket lifecycle
```

No shared state, no concurrent mutation, sockets are created sequentially within each thread's own connection lifecycle — no `EAGAIN`.