### PR TITLE
Close worker-thread connections opened in _send_bulk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 Changelog
 =========
 
+## Unreleased
+* Fixed a bug where SMTP connections opened on `_send_bulk` worker threads were never closed (causing `ResourceWarning: unclosed <ssl.SSLSocket ...>` leaks in production). `ConnectionHandler` now tracks connections across threads so `close()` from the main thread reaches every worker's connection.
+
 ## Version 3.11.2 (2026-04-16)
 * `_send_email` should dispatch email using it's own connection. Thanks @ibadarrohman!
 

--- a/post_office/connections.py
+++ b/post_office/connections.py
@@ -1,4 +1,4 @@
-from threading import local
+import threading
 
 from django.core.mail import get_connection
 
@@ -10,19 +10,23 @@ class ConnectionHandler:
     """
     A Cache Handler to manage access to Cache instances.
 
-    Ensures only one instance of each alias exists per thread.
+    Ensures only one instance of each alias exists per thread. The registry is
+    a process-wide dict keyed by (thread_ident, alias) rather than threading.local
+    so close() called from one thread can reach and close connections opened by
+    worker threads — otherwise SMTP sockets opened inside a ThreadPool worker
+    would leak when _send_bulk closes from the main thread.
     """
 
     def __init__(self):
-        self._connections = local()
+        self._lock = threading.Lock()
+        self._connections = {}
 
     def __getitem__(self, alias):
-        try:
-            return self._connections.connections[alias]
-        except AttributeError:
-            self._connections.connections = {}
-        except KeyError:
-            pass
+        key = (threading.get_ident(), alias)
+        with self._lock:
+            connection = self._connections.get(key)
+        if connection is not None:
+            return connection
 
         try:
             backend = get_backend(alias)
@@ -31,20 +35,24 @@ class ConnectionHandler:
 
         connection = get_connection(backend)
         connection.open()
-        self._connections.connections[alias] = connection
+        with self._lock:
+            self._connections[key] = connection
         return connection
 
     def all(self):
-        return getattr(self._connections, 'connections', {}).values()
+        with self._lock:
+            return list(self._connections.values())
 
     def close(self):
-        for connection in self.all():
+        with self._lock:
+            connections = list(self._connections.values())
+            # Evict closed connections so the next __getitem__ reopens them.
+            # Keeping closed connections cached breaks backends (e.g. Amazon SES)
+            # whose close() nulls out internal clients — subsequent batches would
+            # hand workers a dead connection and race inside send_messages.
+            self._connections.clear()
+        for connection in connections:
             connection.close()
-        # Evict closed connections so the next __getitem__ reopens them.
-        # Keeping closed connections cached breaks backends (e.g. Amazon SES)
-        # whose close() nulls out internal clients — subsequent batches would
-        # hand workers a dead connection and race inside send_messages.
-        self._connections.connections = {}
 
 
 connections = ConnectionHandler()

--- a/tests/test_mail.py
+++ b/tests/test_mail.py
@@ -1,4 +1,5 @@
 import re
+import threading
 import time
 from datetime import timedelta
 from multiprocessing.context import TimeoutError
@@ -34,6 +35,9 @@ from post_office.settings import (
 
 connection_counter = 0
 
+open_close_counter = {'opens': 0, 'closes': 0}
+open_close_counter_lock = threading.Lock()
+
 
 class ConnectionTestingBackend(mail.backends.base.BaseEmailBackend):
     """
@@ -46,6 +50,24 @@ class ConnectionTestingBackend(mail.backends.base.BaseEmailBackend):
 
     def send_messages(self, email_messages):
         pass
+
+
+class OpenCloseCountingBackend(mail.backends.base.BaseEmailBackend):
+    """
+    An EmailBackend that tracks opens and closes (thread-safe) so tests can
+    verify every opened connection is also closed.
+    """
+
+    def open(self):
+        with open_close_counter_lock:
+            open_close_counter['opens'] += 1
+
+    def close(self):
+        with open_close_counter_lock:
+            open_close_counter['closes'] += 1
+
+    def send_messages(self, email_messages):
+        return len(email_messages)
 
 
 class SlowTestBackend(mail.backends.base.BaseEmailBackend):
@@ -172,6 +194,40 @@ class MailTest(TransactionTestCase):
         )
         _send_bulk([email_1, email_2, email_3])
         self.assertEqual(connection_counter, 2)
+
+    @override_settings(
+        EMAIL_BACKEND='tests.test_mail.OpenCloseCountingBackend',
+        POST_OFFICE={
+            'BACKENDS': {
+                'open_close_tester': 'tests.test_mail.OpenCloseCountingBackend',
+            },
+            'THREADS_PER_PROCESS': 2,
+        },
+    )
+    def test_send_bulk_closes_worker_connections(self):
+        """
+        Every connection opened (including those opened on ThreadPool workers)
+        must be closed when _send_bulk finishes. Otherwise SMTP sockets opened
+        on worker threads leak (ResourceWarning: unclosed <ssl.SSLSocket ...>).
+        """
+        open_close_counter['opens'] = 0
+        open_close_counter['closes'] = 0
+        emails = Email.objects.bulk_create(
+            [
+                Email(
+                    to=['to@example.com'],
+                    from_email='bob@example.com',
+                    subject='',
+                    message='',
+                    status=STATUS.queued,
+                    backend_alias='open_close_tester',
+                )
+                for _ in range(5)
+            ]
+        )
+        _send_bulk(emails)
+        self.assertGreater(open_close_counter['opens'], 0)
+        self.assertEqual(open_close_counter['opens'], open_close_counter['closes'])
 
     def test_get_queued(self):
         """


### PR DESCRIPTION
## Problem

PR #521 (released in 3.11.2) moved the email-backend connection open into the ThreadPool workers inside _send_bulk:

    def _send_email(email, log_level):
        connection = connections[email.backend_alias or 'default']
        email.dispatch(..., connection=connection)

But ConnectionHandler stored its registry on a threading.local, so the connections.close() called from the main thread in _send_bulk's finally only saw the main thread's local cache. SMTP connections opened on the worker threads were never .quit()-ed. They survived until garbage collection, producing:

    ResourceWarning: unclosed <ssl.SSLSocket ...>

and leaking file descriptors in long-running send_queued_mail workers.

## Fix

Switch ConnectionHandler from threading.local to a process-wide dict keyed by (threading.get_ident(), alias) under a lock. Per-thread isolation is preserved (each thread still gets its own connection, no sharing or contention), and close() called from any thread now sees and closes every worker's connection.

This preserves the intra-batch connection reuse from #521. _send_email running multiple times on the same worker thread still hits the cache rather than reopening. The existing test_send_bulk_reuses_open_connection still passes at 2 opens for 3 emails (1 main + 1 worker, reused).

I considered the smaller fix of wrapping _send_email's body in a try/finally that calls connections.close() per call. That works but defeats #521's reuse: every email pays a fresh open() (plus STARTTLS, for SMTP). The registry change is the same number of files touched and keeps the perf shape #521 was after, so it seemed the right call. Happy to switch to the per-call close if you prefer the smaller surface.

## Test

Added test_send_bulk_closes_worker_connections: a thread-safe counting backend tracks open() and close() calls; the test runs _send_bulk over 5 emails with THREADS_PER_PROCESS=2 and asserts opens == closes.

- Pre-fix: fails (opens=2, closes=1, the worker's open is never closed).
- Post-fix: passes.

Full test suite still green locally on Django 5.2 (django-admin test post_office ./).
