### PR TITLE
Enhance CodeMirror styling in email template change form.

### DIFF
--- a/post_office/templates/admin/post_office/emailtemplate/change_form.html
+++ b/post_office/templates/admin/post_office/emailtemplate/change_form.html
@@ -30,7 +30,7 @@
         CodeMirror.fromTextArea($('#id_content')[0], options);
         CodeMirror.fromTextArea($('#id_html_content')[0], options);
 
-        $('.CodeMirror').css('height', 'auto');
+        $('.CodeMirror').css('height', 'auto').css('min-width', '30%').css('border', '1px solid var(--border-color)');
       })(django.jQuery);
     </script>
 {% endblock %}


### PR DESCRIPTION
After struggeling to see the input fields for the standard mail templates and seeing #455 and #457 I wanted to add a simple solution.
I added a minimum width to the fields and added the same border as the other Admin input fields.
Now the inputs are clearly visible in the template form and are similar in style to the other Admin inputs.

| Before | After |
|--------|--------|
| <img width="858" height="458" alt="Bildschirmfoto 2026-06-19 um 14 07 46" src="https://github.com/user-attachments/assets/551d192b-8cc6-453d-bf1d-f206b4f48c6d" /> | <img width="862" height="464" alt="Bildschirmfoto 2026-06-19 um 14 07 32" src="https://github.com/user-attachments/assets/69ad47d0-f891-447f-a033-a7dd6ab94008" /> | 
