### PR TITLE
Fix: Close SMTP connections opened in worker threads in _send_bulk()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 Changelog
 =========
 
+## Master
+* Fixed a connection leak in `_send_bulk()`.
+
 ## Version 3.11.2 (2026-04-16)
 * `_send_email` should dispatch email using it's own connection. Thanks @ibadarrohman!
 

--- a/post_office/mail.py
+++ b/post_office/mail.py
@@ -39,17 +39,6 @@ from .utils import (
 logger = setup_loghandlers('INFO')
 
 
-def _send_email(email: Email, log_level: int) -> tuple[bool, Optional[Exception]]:
-    try:
-        connection = connections[email.backend_alias or 'default']
-        email.dispatch(log_level=log_level, commit=False, disconnect_after_delivery=False, connection=connection)
-        logger.debug(f'Successfully sent email #{email.id}')
-        return True, None
-    except Exception as e:
-        logger.exception(f'Failed to send email #{email.id}')
-        return False, e
-
-
 def create(
     sender,
     recipients=None,
@@ -380,12 +369,34 @@ def _send_bulk(
             logger.exception(f'Failed to prepare email #{email.id}')
             failed_emails.append((email, e))
 
+    # The ThreadPool workers open their own connections lazily and reuse them
+    # for every mail they handle. However, those connections cannot be closed by
+    # the main thread's connections.close(). So we collect them and explicitly
+    # close them once all threads have finished.
+    opened_connections = set()
+
+    def _send_email(email):
+        try:
+            connection = connections[email.backend_alias or 'default']
+            opened_connections.add(connection)
+            email.dispatch(
+                log_level=log_level,
+                commit=False,
+                disconnect_after_delivery=False,
+                connection=connection,
+            )
+            logger.debug(f'Successfully sent email #{email.id}')
+            return True, None
+        except Exception as e:
+            logger.exception(f'Failed to send email #{email.id}')
+            return False, e
+
     number_of_threads = min(get_threads_per_process(), email_count)
     try:
         with ThreadPool(number_of_threads) as pool:
             results = []
             for email in emails_to_send:
-                results.append((email, pool.apply_async(_send_email, args=(email, log_level))))
+                results.append((email, pool.apply_async(_send_email, args=(email,))))
 
             timeout = get_batch_delivery_timeout()
 
@@ -398,6 +409,14 @@ def _send_bulk(
                 else:
                     failed_emails.append((email, exception))
     finally:
+        # Close the connections opened inside the worker threads.
+        for connection in opened_connections:
+            try:
+                connection.close()
+            except Exception:
+                logger.exception('Failed to close email connection')
+        opened_connections.clear()
+        # Close any connection opened in the main thread.
         connections.close()
 
     # Update statuses of sent emails

--- a/tests/test_mail.py
+++ b/tests/test_mail.py
@@ -33,6 +33,7 @@ from post_office.settings import (
 )
 
 connection_counter = 0
+close_counter = 0
 
 
 class ConnectionTestingBackend(mail.backends.base.BaseEmailBackend):
@@ -43,6 +44,10 @@ class ConnectionTestingBackend(mail.backends.base.BaseEmailBackend):
     def open(self):
         global connection_counter
         connection_counter += 1
+
+    def close(self):
+        global close_counter
+        close_counter += 1
 
     def send_messages(self, email_messages):
         pass
@@ -172,6 +177,46 @@ class MailTest(TransactionTestCase):
         )
         _send_bulk([email_1, email_2, email_3])
         self.assertEqual(connection_counter, 2)
+
+    @override_settings(
+        EMAIL_BACKEND='tests.test_mail.ConnectionTestingBackend',
+        POST_OFFICE={
+            'BACKENDS': {
+                'connection_tester': 'tests.test_mail.ConnectionTestingBackend',
+            },
+            'THREADS_PER_PROCESS': 2,
+        },
+    )
+    def test_send_bulk_closes_worker_connections(self):
+        """
+        Ensure _send_bulk() closes the connections opened inside the worker
+        threads. These live in each worker's thread-local cache, which the main
+        thread's connections.close() cannot reach, so without explicit cleanup
+        their sockets leak until garbage collection.
+        """
+        global connection_counter, close_counter
+        connection_counter = 0
+        close_counter = 0
+        emails = Email.objects.bulk_create(
+            [
+                Email(
+                    to=['to@example.com'],
+                    from_email='bob@example.com',
+                    subject='',
+                    message='',
+                    status=STATUS.queued,
+                    backend_alias='connection_tester',
+                )
+                for _ in range(6)
+            ]
+        )
+        try:
+            _send_bulk(emails)
+            self.assertGreater(connection_counter, 0)
+            self.assertEqual(close_counter, connection_counter)
+        finally:
+            connection_counter = 0
+            close_counter = 0
 
     def test_get_queued(self):
         """


### PR DESCRIPTION
When sending queued mail, `_send_bulk` runs each send in a `ThreadPool` worker that opens its own connection in thread-local storage. The main thread's `connections.close()` can't access those, so the sockets were leaked and only cleaned up at garbage collection (which triggered a lot of warnings for us). 

To solve this, collect the worker connections and close them once the pool has finished. This keeps re-using one connection per worker thread for the whole batch.